### PR TITLE
添加txt转csv的python脚本，并有运行结果文件

### DIFF
--- a/txt转其他格式/New_Recourse.txt
+++ b/txt转其他格式/New_Recourse.txt
@@ -148,7 +148,6 @@ Chiseled Stone Bricks	錾制石砖
 Chorus Flower	紫颂花
 Chorus Plant	紫颂植株
 Clay	黏土块
-图标	英文名称	中文名称
 Coal Ore	煤矿石
 Coarse Dirt	砂土
 Cobbled Deepslate	深板岩圆石

--- a/txt转其他格式/Translations.csv
+++ b/txt转其他格式/Translations.csv
@@ -1,0 +1,896 @@
+﻿enName,cnName
+Acacia Door,金合欢木门
+Acacia Fence Gate,金合欢木栅栏门
+Acacia Log,金合欢原木
+Acacia Pressure Plate,金合欢木压力板
+Acacia Sign,金合欢木告示牌
+Acacia Stairs,金合欢木楼梯
+Acacia Wall Sign,墙上的金合欢木告示牌
+Activator Rail,激活铁轨
+Allium,绒球葱
+Amethyst Cluster,紫水晶簇
+Andesite,安山岩
+Andesite Stairs,安山岩楼梯
+Anvil,铁砧
+Attached Pumpkin Stem,结果的南瓜茎
+Azalea Leaves,杜鹃树叶
+Bamboo Sapling,竹笋
+Banner,旗帜
+Barrier,屏障
+Beacon,信标
+Bedrock,基岩
+Beehive,蜂箱
+Bell,钟
+Big Dripleaf Stem,大型垂滴叶茎
+Birch Door,白桦木门
+Birch Fence Gate,白桦木栅栏门
+Birch Log,白桦原木
+Birch Pressure Plate,白桦木压力板
+Birch Sign,白桦木告示牌
+Birch Stairs,白桦木楼梯
+Birch Wall Sign,墙上的白桦木告示牌
+Black Wall Banner,墙上的黑色旗帜
+Blackstone Slab,黑石台阶
+Blackstone Wall,黑石墙
+Block of Amethyst,紫水晶块
+Block of Copper,铜块
+Block of Emerald,绿宝石块
+Block of Iron,铁块
+Block of Netherite,下界合金块
+Block of Raw Copper,粗铜块
+Block of Raw Iron,粗铁块
+Blue Ice,蓝冰
+Blue Wall Banner,墙上的蓝色旗帜
+Bookshelf,书架
+Brain Coral Block,脑纹珊瑚块
+Brain Coral Wall Fan,墙上的脑纹珊瑚扇
+Brick Slab,砖台阶
+Brick Wall,砖块墙
+Brown Mushroom,棕色蘑菇
+Brown Wall Banner,墙上的棕色旗帜
+Bubble Coral,气泡珊瑚
+Bubble Coral Fan,气泡珊瑚扇
+Budding Amethyst,紫水晶母岩
+Cactus,仙人掌
+Cake With Black Candle,插上黑色蜡烛的蛋糕
+Cake With Brown Candle,插上棕色蜡烛的蛋糕
+Cake With Cyan Candle,插上青色蜡烛的蛋糕
+Cake With Green Candle,插上绿色蜡烛的蛋糕
+Cake With Light Gray Candle,插上淡灰色蜡烛的蛋糕
+Cake With Magenta Candle,插上品红色蜡烛的蛋糕
+Cake With Pink Candle,插上粉红色蜡烛的蛋糕
+Cake With Red Candle,插上红色蜡烛的蛋糕
+Cake With Yellow Candle,插上黄色蜡烛的蛋糕
+Campfire,营火
+Carpet,地毯
+Cartography Table,制图台
+Cauldron,炼药锅
+Cave Vines,洞穴藤蔓
+Chain,锁链
+Chalkboard,黑板
+Chipped Anvil,开裂的铁砧
+Chiseled Nether Bricks,錾制下界砖块
+Chiseled Quartz Block,錾制石英块
+Chiseled Sandstone,錾制砂岩
+Chorus Flower,紫颂花
+Clay,黏土块
+Coarse Dirt,砂土
+Cobbled Deepslate Slab,深板岩圆石台阶
+Cobbled Deepslate Wall,深板岩圆石墙
+Cobblestone Slab,圆石台阶
+Cobblestone Wall,圆石墙
+Cocoa,可可果
+Colored Terracotta,染色陶瓦
+Command Block,命令方块
+Concrete,混凝土
+Conduit,潮涌核心
+Coral,珊瑚
+Coral Blocks,珊瑚块
+Coral Fans,珊瑚扇
+Cracked Deepslate Bricks,裂纹深板岩砖
+Cracked Nether Bricks,裂纹下界砖块
+Cracked Stone Bricks,裂纹石砖
+Creeper Head,苦力怕的头
+Crimson Button,绯红木按钮
+Crimson Fence,绯红木栅栏
+Crimson Fungus,绯红菌
+Crimson Nylium,绯红菌岩
+Crimson Pressure Plate,绯红木压力板
+Crimson Sign,绯红木告示牌
+Crimson Stairs,绯红木楼梯
+Crimson Trapdoor,绯红木活板门
+Crying Obsidian,哭泣的黑曜石
+Cut Copper Slab,切制铜台阶
+Cut Red Sandstone,切制红砂岩
+Cut Sandstone,切制砂岩
+Cyan Flower,青花
+Damaged Anvil,损坏的铁砧
+Dark Oak Button,深色橡木按钮
+Dark Oak Fence,深色橡木栅栏
+Dark Oak Leaves,深色橡树树叶
+Dark Oak Planks,深色橡木木板
+Dark Oak Sapling,深色橡树树苗
+Dark Oak Slab,深色橡木台阶
+Dark Oak Trapdoor,深色橡木活板门
+Dark Oak Wood,深色橡木
+Dark Prismarine Slab,暗海晶石台阶
+Daylight Detector,阳光探测器
+Dead Brain Coral,失活的脑纹珊瑚
+Dead Brain Coral Fan,失活的脑纹珊瑚扇
+Dead Bubble Coral,失活的气泡珊瑚
+Dead Bubble Coral Fan,失活的气泡珊瑚扇
+Dead Bush,枯萎的灌木
+Dead Coral Blocks,失活的珊瑚块
+Dead Fire Coral,失活的火珊瑚
+Dead Fire Coral Fan,失活的火珊瑚扇
+Dead Horn Coral,失活的鹿角珊瑚
+Dead Horn Coral Fan,失活的鹿角珊瑚扇
+Dead Tube Coral,失活的管珊瑚
+Dead Tube Coral Fan,失活的管珊瑚扇
+Deepslate,深板岩
+Deepslate Brick Stairs,深板岩砖楼梯
+Deepslate Bricks,深板岩砖
+Deepslate Copper Ore,深层铜矿石
+Deepslate Emerald Ore,深层绿宝石矿石
+Deepslate Iron Ore,深层铁矿石
+Deepslate Lapis Ore,深层青金石矿石
+Deepslate Tile Slab,深板岩瓦台阶
+Deepslate Tile Wall,深板岩瓦墙
+Detector Rail,探测铁轨
+Diorite,闪长岩
+Diorite Slab,闪长岩台阶
+Diorite Wall,闪长岩墙
+Dirt Path,土径
+Door,门
+Dragon Egg,龙蛋
+Dragon Wall Head,墙上的龙首
+Dripstone Block,滴水石块
+Dye,染料
+Dyed Carpet,染色地毯
+Dyed Terracotta,染色陶瓦
+Emerald Ore,绿宝石矿石
+Enchanting Table,附魔台
+End Gateway,末地折跃门
+End Portal Frame,末地传送门框架
+End Stone,末地石
+End Stone Brick Stairs,末地石砖楼梯
+End Stone Bricks,末地石砖
+Exposed Copper,斑驳的铜块
+Exposed Cut Copper Slab,斑驳的切制铜台阶
+Fake Wood Slab,伪木台阶
+Fence,栅栏
+Fern,蕨
+Fire,火
+Fire Coral Block,火珊瑚块
+Fire Coral Wall Fan,墙上的火珊瑚扇
+Fletching Table,制箭台
+Flower Pot,花盆
+Flowering Azalea Leaves,盛开的杜鹃树叶
+Frog Spawn,青蛙卵
+Fungi,菌类
+Furnace,熔炉
+Gilded Blackstone,镶金黑石
+Glass Pane,玻璃板
+Glow Lichen,发光地衣
+Gold Ore,金矿石
+Granite Bell,花岗岩钟
+Granite Stairs,花岗岩楼梯
+Grass,草
+Grass Path,草径
+Gray Wall Banner,墙上的灰色旗帜
+Grindstone,砂轮
+Hay Bale,干草块
+Heavy Weighted Pressure Plate,重质测重压力板
+Honeycomb Block,蜜脾块
+Horn Coral,鹿角珊瑚
+Horn Coral Fan,鹿角珊瑚扇
+Huge Brown Mushroom,棕色巨型蘑菇
+Huge Red Mushroom,红色巨型蘑菇
+Ice,冰
+Infested Block,被虫蚀的方块
+Infested Cobblestone,被虫蚀的圆石
+Infested Deepslate,被虫蚀的深板岩
+Infested Stone,被虫蚀的石头
+Initialized Nether Reactor Core,激活的下界反应核
+Inverted Daylight Sensor,反向阳光探测器
+Iron Door,铁门
+Iron Trapdoor,铁活板门
+Jigsaw Block,拼图方块
+Jungle Button,丛林木按钮
+Jungle Fence,丛林木栅栏
+Jungle Leaves,丛林树叶
+Jungle Planks,丛林木板
+Jungle Sapling,丛林树苗
+Jungle Slab,丛林木台阶
+Jungle Trapdoor,丛林木活板门
+Jungle Wood,丛林木
+Ladder,梯子
+Lapis Lazuli Block,青金石块
+Large Amethyst Bud,大型紫晶芽
+Lava,熔岩
+Leaves,树叶
+Lever,拉杆
+Light 0,光
+Light 10,光
+Light 12,光
+Light 14,光
+Light 2,光
+Light 4,光
+Light 6,光
+Light 8,光
+Light Blue Wall Banner,墙上的淡蓝色旗帜
+Light Negative,光
+Lightning Rod,避雷针
+Lily of The Valley,铃兰
+Lime Wall Banner,墙上的黄绿色旗帜
+Lit Deepslate Redstone Ore,点亮的深层红石矿石
+Lit Redstone Lamp,点亮的红石灯
+Lit Smoker,燃烧中的烟熏炉
+Lodestone,磁石
+Loom,织布机
+Magma Block,岩浆块
+Melon,西瓜
+Mob Head,生物头颅
+Moss Carpet,苔藓地毯
+Mossy Cobblestone,苔石
+Mossy Cobblestone Stairs,苔石楼梯
+Mossy Stone Brick Slab,苔石砖台阶
+Mossy Stone Brick Wall,苔石砖墙
+Moving Block,移动的方块
+Mushroom,蘑菇
+Mushroom Stem,蘑菇柄
+Nether Brick Fence,下界砖栅栏
+Nether Brick Stairs,下界砖楼梯
+Nether Bricks,下界砖块
+Nether Planks,下界木板
+Nether Quartz Ore,下界石英矿石
+Nether Wart,下界疣
+Nether Wood Fence,下界木质栅栏
+Netherrack,下界岩
+Nylium,菌岩
+Oak Door,橡木门
+Oak Fence Gate,橡木栅栏门
+Oak Log,橡木原木
+Oak Pressure Plate,橡木压力板
+Oak Sign,橡木告示牌
+Oak Stairs,橡木楼梯
+Oak Wall Sign,墙上的橡木告示牌
+Observer,侦测器
+Ominous Banner,灾厄旗帜
+Orange Wall Banner,墙上的橙色旗帜
+Overworld Planks,主世界木板
+Overworld Stripped Wood,主世界去皮木头
+Overworld Wood Fence,主世界木质栅栏
+Oxeye Daisy,滨菊
+Oxidized Cut Copper,氧化的切制铜块
+Oxidized Cut Copper Stairs,氧化的切制铜楼梯
+Peony,牡丹
+Pink Tulip,粉红色郁金香
+Piston,活塞
+Plank,木板
+Player Wall Head,墙上的玩家头颅
+Pointed Dripstone,滴水石锥
+Polished Andesite Slab,磨制安山岩台阶
+Polished Basalt,磨制玄武岩
+Polished Blackstone Brick Slab,磨制黑石砖台阶
+Polished Blackstone Brick Wall,磨制黑石砖墙
+Polished Blackstone Button,磨制黑石按钮
+Polished Blackstone Slab,磨制黑石台阶
+Polished Blackstone Wall,磨制黑石墙
+Polished Deepslate Slab,磨制深板岩台阶
+Polished Deepslate Wall,磨制深板岩墙
+Polished Diorite Slab,磨制闪长岩台阶
+Polished Granite,磨制花岗岩
+Polished Granite Slab,磨制花岗岩台阶
+Poppy,虞美人
+Potted Acacia Sapling,金合欢树苗盆栽
+Potted Azalea,杜鹃花丛盆栽
+Potted Bamboo,竹子盆栽
+Potted Blue Orchid,兰花盆栽
+Potted Cactus,仙人掌盆栽
+Potted Crimson Fungus,绯红菌盆栽
+Potted Dandelion,蒲公英盆栽
+Potted Dead Bush,枯萎的灌木盆栽
+Potted Flowering Azalea,盛开的杜鹃花丛盆栽
+Potted Lily of The Valley,铃兰盆栽
+Potted Orange Tulip,橙色郁金香盆栽
+Potted Pink Tulip,粉红色郁金香盆栽
+Potted Red Mushroom,红色蘑菇盆栽
+Potted Spruce Sapling,云杉树苗盆栽
+Potted Warped Roots,诡异菌索盆栽
+Potted Wither Rose,凋零玫瑰盆栽
+Powder Snow Cauldron,装有细雪的炼药锅
+Powered Redstone Comparator,激活的红石比较器
+Pressure Plate,压力板
+Prismarine Brick Slab,海晶石砖台阶
+Prismarine Bricks,海晶石砖
+Prismarine Stairs,海晶石楼梯
+Pumpkin,南瓜
+Purple Wall Banner,墙上的紫色旗帜
+Purpur Pillar,紫珀柱
+Purpur Stairs,紫珀楼梯
+Quartz Bricks,石英砖
+Quartz Slab,石英台阶
+Rail,铁轨
+Red Mushroom Block,红色蘑菇方块
+Red Nether Brick Stairs,红色下界砖楼梯
+Red Nether Bricks,红色下界砖块
+Red Sandstone,红砂岩
+Red Sandstone Stairs,红砂岩楼梯
+Red Tulip,红色郁金香
+Redstone Comparator,红石比较器
+Redstone Ore,红石矿石
+Redstone Torch,红石火把
+Redstone Wire,红石线
+Respawn Anchor,重生锚
+Roots,菌索
+Rose Bush,玫瑰丛
+Sandstone,砂岩
+Sandstone Stairs,砂岩楼梯
+Sapling,树苗
+Sea Lantern,海晶灯
+Seagrass,海草
+Shulker Box,潜影盒
+Skeleton Skull,骷髅头颅
+Slab,台阶
+Slightly Damaged Anvil,轻微损坏的铁砧
+Small Amethyst Bud,小型紫晶芽
+Smithing Table,锻造台
+Smooth Basalt,平滑玄武岩
+Smooth Quartz Block,平滑石英块
+Smooth Quartz Stairs,平滑石英楼梯
+Smooth Red Sandstone Slab,平滑红砂岩台阶
+Smooth Sandstone,平滑砂岩
+Smooth Sandstone Stairs,平滑砂岩楼梯
+Smooth Stone Slab,平滑石头台阶
+Snow Block,雪块
+Soul Fire,灵魂火
+Soul Sand,灵魂沙
+Soul Torch,灵魂火把
+Spawner,刷怪笼
+Spore Blossom,孢子花
+Spruce Door,云杉木门
+Spruce Fence Gate,云杉木栅栏门
+Spruce Log,云杉原木
+Spruce Pressure Plate,云杉木压力板
+Spruce Sign,云杉木告示牌
+Spruce Stairs,云杉木楼梯
+Spruce Wall Sign,墙上的云杉木告示牌
+Stained Glass,染色玻璃
+Stairs,楼梯
+Sticky Piston,黏性活塞
+Stone Brick Slab,石砖台阶
+Stone Brick Wall,石砖墙
+Stone Bricks Slab,石砖台阶
+Stone Pressure Plate,石头压力板
+Stone Stairs,石头楼梯
+Stonecutter,切石机
+Stripped Acacia Wood,去皮金合欢木
+Stripped Birch Wood,去皮白桦木
+Stripped Crimson Stem,去皮绯红菌柄
+Stripped Dark Oak Wood,去皮深色橡木
+Stripped Jungle Log,去皮丛林原木
+Stripped Log,去皮原木
+Stripped Oak Wood,去皮橡木
+Stripped Spruce Wood,去皮云杉木
+Stripped Warped Hyphae,去皮诡异菌核
+Stripped Wood,去皮木头
+Structure Void,结构空位
+Sunflower,向日葵
+Tall Grass,高草丛
+Target,标靶
+Tinted Glass,遮光玻璃
+Torch,火把
+Trapped Chest,陷阱箱
+Tripwire Hook,绊线钩
+Tube Coral Block,管珊瑚块
+Tube Coral Wall Fan,墙上的管珊瑚扇
+Tulips,郁金香
+Twisting Vines,缠怨藤
+Unlit Redstone Torch,熄灭的红石火把
+Unpowered Redstone Repeater,未激活的红石中继器
+Vines,藤蔓
+Wall,墙
+Wall Torch,墙上的火把
+Warped Door,诡异木门
+Warped Fence Gate,诡异木栅栏门
+Warped Hyphae,诡异菌核
+Warped Planks,诡异木板
+Warped Roots,诡异菌索
+Warped Slab,诡异木台阶
+Warped Stem,诡异菌柄
+Warped Wall Sign,墙上的诡异木告示牌
+Water,水
+Wax Block,蜂蜡块
+Waxed Cut Copper,涂蜡切制铜块
+Waxed Cut Copper Stairs,涂蜡切制铜楼梯
+Waxed Exposed Cut Copper,斑驳的涂蜡切制铜块
+Waxed Exposed Cut Copper Stairs,斑驳的涂蜡切制铜楼梯
+Waxed Oxidized Cut Copper,氧化的涂蜡切制铜块
+Waxed Oxidized Cut Copper Stairs,氧化的涂蜡切制铜楼梯
+Waxed Weathered Cut Copper,锈蚀的涂蜡切制铜块
+Waxed Weathered Cut Copper Stairs,锈蚀的涂蜡切制铜楼梯
+Weathered Cut Copper,锈蚀的切制铜块
+Weathered Cut Copper Stairs,锈蚀的切制铜楼梯
+Weeping Vines Plant,垂泪藤植株
+Wet Sponge,湿海绵
+Wheat Crops,小麦
+White Wall Banner,墙上的白色旗帜
+Wither Skeleton Skull,凋灵骷髅头颅
+Wood,木头
+Wood Slab,木质台阶
+Wooden Button,木质按钮
+Wooden Fence,木质栅栏
+Wooden Pressure Plate,木质压力板
+Wooden Stairs,木质楼梯
+Wool,羊毛
+Zombie Head,僵尸的头
+Acacia Boat,金合欢木船
+Apple,苹果
+Arrow Loaded Crossbow,装填箭的弩
+Arrow of Fire Resistance,抗火之箭
+Arrow of Healing,治疗之箭
+Arrow of Leaping,跳跃之箭
+Arrow of Night Vision,夜视之箭
+Arrow of Regeneration,再生之箭
+Arrow of Slowness,迟缓之箭
+Arrow of Strength,力量之箭
+Arrow of The Turtle Master,神龟之箭
+Arrow of Weakness,虚弱之箭
+Awkward Potion,粗制的药水
+Axe,斧
+Bamboo,竹子
+Banner Pattern Bordure Indented,旗帜图案
+Banner Pattern Creeper Charge,旗帜图案
+Banner Pattern Flower,旗帜图案
+Banner Pattern Globe,旗帜图案
+Banner Pattern Skull,旗帜图案
+Banner Pattern Thing,旗帜图案
+Beetroot Seeds,甜菜种子
+Birch Boat,白桦木船
+Blaze Powder,烈焰粉
+Blue Dye,蓝色染料
+Bone,骨头
+Book,书
+Boots,靴子
+Bow,弓
+Bread,面包
+Broken Elytra,破损的鞘翅
+Bucket,桶
+Bucket of Cod,鳕鱼桶
+Bucket of Salmon,鲑鱼桶
+Bucket of Tropical Fish,热带鱼桶
+Buried Treasure Map,藏宝图
+Candle,蜡烛
+Carrot On a Stick,胡萝卜钓竿
+Chainmail Boots,锁链靴子
+Chainmail Helmet,锁链头盔
+Charcoal,木炭
+Chorus Fruit,紫颂果
+Clock,时钟
+Coal,煤炭
+Cod Bucket,鳕鱼桶
+Compass,指南针
+Cooked Chicken,熟鸡肉
+Cooked Fish,熟鱼
+Cooked Porkchop,熟猪排
+Cooked Salmon,熟鲑鱼
+Copper Ingot,铜锭
+Crystallized Honey,结晶蜜
+Dandelion Yellow,蒲公英黄
+Debug Stick,调试棒
+Diamond Axe,钻石斧
+Diamond Chestplate,钻石胸甲
+Diamond Hoe,钻石锄
+Diamond Leggings,钻石护腿
+Diamond Shovel,钻石锹
+Dragon's Breath,龙息
+Egg,鸡蛋
+Emerald,绿宝石
+Empty Map,空地图
+Enchanted Golden Apple,附魔金苹果
+Ender Pearl,末影珍珠
+Eye of Ender,末影之眼
+Fermented Spider Eye,发酵蛛眼
+Filled Map,地图
+Firework Loaded Crossbow,装填烟花的弩
+Firework Star,烟火之星
+Fishing Rod,钓鱼竿
+Flint And Steel,打火石
+Ghast Tear,恶魂之泪
+Glistering Melon,闪烁的西瓜片
+Glow Berries,发光浆果
+Glow Item Frame,荧光物品展示框
+Goat Horn,山羊角
+Gold Nugget,金粒
+Golden Armor,金质盔甲
+Golden Boots,金靴子
+Golden Chestplate,金胸甲
+Golden Hoe,金锄
+Golden Leggings,金护腿
+Golden Shovel,金锹
+Golden Tools,金质工具
+Green Dye,绿色染料
+Half Filled Bundle,收纳袋
+Helmet,头盔
+Honey Bottle,蜂蜜瓶
+Horse Armor,马铠
+Iron Armor,铁质盔甲
+Iron Boots,铁靴子
+Iron Helmet,铁头盔
+Iron Horse Armor,铁马铠
+Iron Leggings,铁护腿
+Iron Pickaxe,铁镐
+Iron Sword,铁剑
+Item Frame,物品展示框
+Kelp,海带
+Lapis Lazuli,青金石
+Lead,拴绳
+Leather Armor,皮革盔甲
+Leather Cap,皮革帽子
+Leather Pants,皮革裤子
+Leggings,护腿
+Light Gray Dye,淡灰色染料
+Lingering Potion,滞留药水
+Lingering Potion of Fire Resistance,滞留型抗火药水
+Lingering Potion of Healing,滞留型治疗药水
+Lingering Potion of Leaping,滞留型跳跃药水
+Lingering Potion of Night Vision,滞留型夜视药水
+Lingering Potion of Regeneration,滞留型再生药水
+Lingering Potion of Slowness,滞留型迟缓药水
+Lingering Potion of Swiftness,滞留型迅捷药水
+Lingering Potion of Water Breathing,滞留型水肺药水
+Lingering Water Bottle,滞留型水瓶
+Lodestone Compass,磁石指针
+Magma Cream,岩浆膏
+Melon Seeds,西瓜种子
+Milk Bucket,奶桶
+Minecart With Chest,运输矿车
+Minecart With Dispenser,发射器矿车
+Minecart With Hopper,漏斗矿车
+Minecart With Spawner,刷怪笼矿车
+Mundane Lingering Potion,滞留型平凡的药水
+Mundane Splash Potion,喷溅型平凡的药水
+Music Disc,音乐唱片
+Music Disc 13,音乐唱片
+Music Disc Cat,音乐唱片
+Music Disc Far,音乐唱片
+Music Disc Mellohi,音乐唱片
+Music Disc Pigstep,音乐唱片
+Music Disc Strad,音乐唱片
+Music Disc Ward,音乐唱片
+Nautilus Shell,鹦鹉螺壳
+Nether Quartz,下界石英
+Netherite Axe,下界合金斧
+Netherite Chestplate,下界合金胸甲
+Netherite Hoe,下界合金锄
+Netherite Leggings,下界合金护腿
+Netherite Scrap,下界合金碎片
+Netherite Sword,下界合金剑
+Ocean Explorer Map,海洋探险家地图
+Painting,画
+Phantom Membrane,幻翼膜
+Pink Dye,粉红色染料
+Popped Chorus Fruit,爆裂紫颂果
+Potato,马铃薯
+Potion of Decay,衰变药水
+Potion of Harming,伤害药水
+Potion of Invisibility,隐身药水
+Potion of Luck,幸运药水
+Potion of Poison,剧毒药水
+Potion of Slow Falling,缓降药水
+Potion of Strength,力量药水
+Potion of The Turtle Master,神龟药水
+Potion of Weakness,虚弱药水
+Prismarine Crystals,海晶砂粒
+Pufferfish,河豚
+Pumpkin Pie,南瓜派
+Purple Dye,紫色染料
+Rabbit Stew,兔肉煲
+Raw Beef,生牛肉
+Raw Cod,生鳕鱼
+Raw Fish,生鱼
+Raw Iron,粗铁
+Raw Porkchop,生猪排
+Raw Salmon,生鲑鱼
+Redstone,红石粉
+Rose Red,玫瑰红
+Saddle,鞍
+Scute,鳞甲
+Shears,剪刀
+Shovel,锹
+Slimeball,黏液球
+Spawn Egg,刷怪蛋
+Spider Eye,蜘蛛眼
+Splash Mundane Potion,喷溅型平凡的药水
+Splash Potion of Decay,喷溅型衰变药水
+Splash Potion of Harming,喷溅型伤害药水
+Splash Potion of Invisibility,喷溅型隐身药水
+Splash Potion of Luck,喷溅型幸运药水
+Splash Potion of Poison,喷溅型剧毒药水
+Splash Potion of Slow Falling,喷溅型缓降药水
+Splash Potion of Strength,喷溅型力量药水
+Splash Potion of The Turtle Master,喷溅型神龟药水
+Splash Potion of Weakness,喷溅型虚弱药水
+Spruce Boat,云杉木船
+Steak,牛排
+Stone Axe,石斧
+Stone Pickaxe,石镐
+Stone Sword,石剑
+Sugar,糖
+Sweet Berries,甜浆果
+Thick Lingering Potion,滞留型浓稠的药水
+Thick Splash Potion,喷溅型浓稠的药水
+Totem of Undying,不死图腾
+Tropical Fish,热带鱼
+Turtle Shell,海龟壳
+Uncraftable Potion,不可合成的药水
+Uncraftable Tipped Arrow,不可合成的药箭
+Warped Fungus On a Stick,诡异菌钓竿
+Water Bucket,水桶
+Wheat Seeds,小麦种子
+Wooden Axe,木斧
+Wooden Pickaxe,木镐
+Wooden Sword,木剑
+Written Book,成书
+Agent,智能体
+Armor Stand,盔甲架
+Bat,蝙蝠
+Black Cat,猫
+Brown Mooshroom,棕色哞菇
+Cave Spider,洞穴蜘蛛
+Chicken,鸡
+Cod,鳕鱼
+Creeper,苦力怕
+Donkey,驴
+Drowned,溺尸
+Ender Crystal,末影水晶
+Enderman,末影人
+Evoker,唤魔者
+Experience Orb,经验球
+Fishing Bobber,浮漂
+Frog,青蛙
+Giant,巨人
+Goat,山羊
+Hoglin,疣猪兽
+Human,人类
+Illager,灾厄村民
+Illusioner,幻术师
+Item,物品
+Leash Knot,拴绳结
+Llama,羊驼
+Magma Cube,岩浆怪
+Mask,Mask
+Mule,骡
+Ocelot,豹猫
+Parrot,鹦鹉
+Pig,猪
+Piglin Brute,猪灵蛮兵
+Pillager,掠夺者
+Polar Bear,北极熊
+Rabbit,兔子
+Red Cat,猫
+Salmon,鲑鱼
+Sheep,绵羊
+Shulker Bullet,潜影贝导弹
+Siamese Cat,猫
+Skeleton,骷髅
+Skeleton Horseman,骷髅骑手
+Small Fireball,小火球
+Spider,蜘蛛
+Spider Jockey,蜘蛛骑士
+Stray,流浪者
+Tadpole,蝌蚪
+Trader Llama,行商羊驼
+Turtle,海龟
+Villager,村民
+Wandering Trader,流浪商人
+Witch,女巫
+Wither Skeleton,凋灵骷髅
+Wolf,狼
+Zombie,僵尸
+Zombie Pigman,僵尸猪人
+Zombified Piglin,僵尸猪灵
+Fire Protection,火焰保护
+Blast Protection,爆炸保护
+Respiration,水下呼吸
+Thorns,荆棘
+Frost Walker,冰霜行者
+Sharpness,锋利
+Bane of Arthropods,节肢杀手
+Fire Aspect,火焰附加
+Sweeping Edge,横扫之刃
+Silk Touch,精准采集
+Fortune,时运
+Punch,冲击
+Infinity,无限
+Lure,饵钓
+Curse of Vanishing,消失诅咒
+Channeling,引雷
+Impaling,穿刺
+Multishot,多重射击
+Soul Speed,灵魂疾行
+Easy,简单
+Hard,困难
+Survival,生存模式
+Adventure,冒险模式
+Demo,演示模式（演示版）
+Survival Multiplayer （SMP）,多人生存模式
+Creative Multiplayer （CMP）,多人创造模式
+Hardcore Multiplayer （HMP）,多人极限模式
+Adventure Multiplayer （AMP）,多人冒险模式
+Accessibility,辅助功能
+Attack indicator,攻击指示器
+Loot table,战利品表
+Heads-up display（HUD）,抬头显示器/平视显示器（常用HUD）
+Hotbar,快捷栏
+Slot,槽位
+Renewable resource,可再生资源
+Scoreboard,记分板
+Status effect,状态效果
+Waterlogging,含水
+Breeding,繁殖
+Farming,耕种
+Recipe book,配方书
+Health,生命
+Hunger,饥饿
+Smelting,烧炼
+Blocking,防御
+Sneaking,潜行
+Transportation,运输
+Tutorial hint,教学提示
+Raid,袭击
+Mojang,（不翻译）
+Launcher,启动器
+Bedrock Edition,基岩版
+Java Edition,Java版
+New Nintendo 3DS Edition,New Nintendo 3DS版
+Version history,版本记录
+Upcoming,即将到来
+Feature,特性（通用）
+Indev/Infdev/Alpha/Beta,（不翻译）
+Full release,正式版
+Pre-release,预发布版
+Mentioned feature,提及特性
+Exclusive feature,独有特性
+Easter egg,彩蛋
+Adventure Update,冒险更新
+Horse Update,马匹更新
+Frostburn Update,霜炙更新
+Colorful Update,多彩世界更新
+Village and Pillage,村庄与掠夺
+Nether Update,下界更新
+Pocket Edition Alpha,携带版Alpha
+Bedrock Edition alpha,基岩版alpha
+Ender Update,末影更新
+Better Together Update,独乐不如众乐更新
+Biome,生物群系
+Chunk,区块
+The Void,虚空
+Projectile,弹射物
+Dimension,维度
+The Nether,下界
+Default,默认
+Superflat,超平坦
+Debug mode,调试模式
+Buffet,自选
+Floating island,浮岛
+Mountain,山脉
+Far Land,边境之地
+Stronghold,要塞
+Dungeon,地牢
+Iceberg,冰山
+Mossy cobblestone boulder,生苔的巨石
+Coral reef,珊瑚礁
+Desert temple,沙漠神殿
+Woodland mansion,林地府邸
+Witch hut,沼泽小屋
+Lava sea,熔岩海
+End city,末地城
+End gateway,末地折跃门
+Nether portal,下界传送门
+Opacity,不透明度
+Thunderstorm,雷暴
+Monolith,独石柱（暂译）
+Enchanting library,附魔用图书馆
+Apprentice,学徒
+Expert,专家
+Ocean ruins,海底废墟
+Basalt pillar,玄武岩柱
+Bastion remnant,堡垒遗迹
+Add-on,附加包
+Artifact,意外的……纹理、缺陷
+Block state（BS）,方块状态（通称BS）
+Bug,漏洞
+Common,普通（共通）
+Crash,崩溃
+Data value（DV）,数据值（通称DV）
+Debug screen,调试界面
+Dummy,虚拟型
+Fixes,修复
+Formatting code,格式化代码
+Function,函数（功能）
+GUI,图形用户界面（通常不翻译）
+ID,（不翻译）
+Long,长整型
+Material,材质（定义渲染映射）
+Mob cap,生物容量
+Modify,修改
+NBT,（不翻译）
+Outdated,过期（过时）
+Particle,粒子
+Present,选定
+Respawn,重生
+Setting,设置
+Spawn point,出生点
+String,字符串
+Template,模板
+Tick,刻
+Tile,（不翻译）
+Added...,加入了……
+Available,可用的
+Chance,概率
+Destroy,摧毁
+Disambiguation,消歧义
+Gameplay,游戏内容
+Implement,实现
+Interwiki,跨Wiki链接（通常不翻译）
+Label,标签
+Manufacture,人造
+Obtain,获取
+Redirect,重定向
+Release,发布
+Sandbox,沙盒
+See also,参见
+Stack,堆叠数（组）
+Trivia,你知道吗
+Usage,用途（用法）
+Variant,变种
+Workplace,工作站点
+ocean,海洋
+desert,沙漠
+forest,森林
+swamp,沼泽
+nether_wastes,下界荒地
+frozen_ocean,冻洋
+snowy_plains,积雪的平原
+beach,沙滩
+sparse_jungle,稀疏的丛林
+stony_shore,石岸
+birch_forest,桦木森林
+snowy_taiga,积雪的针叶林
+windswept_forest,风袭森林
+savanna_plateau,热带高原
+wooded_badlands,繁茂的恶地
+end_midlands,末地中型岛屿
+end_barrens,末地荒岛
+lukewarm_ocean,温水海洋
+deep_lukewarm_ocean,温水深海
+deep_frozen_ocean,冰冻深海
+sunflower_plains,向日葵平原
+flower_forest,繁花森林
+old_growth_birch_forest,原始桦木森林
+windswept_savanna,风袭热带草原
+bamboo_jungle,竹林
+crimson_forest,绯红森林
+basalt_deltas,玄武岩三角洲
+lush_caves,繁茂洞穴
+grove,雪林
+frozen_peaks,冰封山峰
+stony_peaks,裸岩山峰
+slowness,缓慢
+mining_fatigue,挖掘疲劳
+instant_health,瞬间治疗
+jump_boost,跳跃提升
+regeneration,生命恢复
+fire_resistance,防火
+invisibility,隐身
+night_vision,夜视
+weakness,虚弱
+wither,凋零
+absorption,伤害吸收
+glowing,发光
+luck,幸运
+slow_falling,缓降
+dolphins_grace,海豚的恩惠
+hero_of_the_village,村庄英雄

--- a/txt转其他格式/Translations.csv
+++ b/txt转其他格式/Translations.csv
@@ -660,7 +660,6 @@ Item,物品
 Leash Knot,拴绳结
 Llama,羊驼
 Magma Cube,岩浆怪
-Mask,Mask
 Mule,骡
 Ocelot,豹猫
 Parrot,鹦鹉

--- a/txt转其他格式/txt-to-csv.py
+++ b/txt转其他格式/txt-to-csv.py
@@ -1,0 +1,43 @@
+# coding = utf-8
+
+import pandas as pd
+
+# 检验是否含有中文字符
+# 函数来自网址页面：https://segmentfault.com/a/1190000017940752
+def is_contains_chinese(strs):
+    for _char in strs:
+        if '\u4e00' <= _char <= '\u9fa5':
+            return True
+    return False
+
+nameFile = open('New_Recourse.txt', 'r', encoding = 'utf-8')
+curLine = ''
+cnList = []
+enList = []
+
+for lines in nameFile:
+    curLine = nameFile.readline()
+
+    if not curLine:
+        continue
+
+    curLine = curLine.replace('\n', '')
+    lineContent = curLine.split('\t')
+
+    if(len(lineContent) != 2):
+        continue
+    
+    if(is_contains_chinese(lineContent[0]) == True):
+        cnList.append(lineContent[0])
+        enList.append(lineContent[1])
+    else:
+        cnList.append(lineContent[1])
+        enList.append(lineContent[0])
+
+#dataNames = [enList, cnList]
+#print(len(dataNames[0]))
+#print(len(dataNames[1]))
+
+df = pd.DataFrame({'enName':enList, 'cnName':cnList})
+
+df.to_csv("Translations.csv", index = False, sep = ',', encoding = 'utf-8-sig')

--- a/txt转其他格式/txt-to-csv.py
+++ b/txt转其他格式/txt-to-csv.py
@@ -10,34 +10,35 @@ def is_contains_chinese(strs):
             return True
     return False
 
-nameFile = open('New_Recourse.txt', 'r', encoding = 'utf-8')
+nameFile = open('New_Recourse.txt', 'r', encoding = 'utf-8')    # 以UTF-8格式打开txt
 curLine = ''
 cnList = []
 enList = []
 
-for lines in nameFile:
+for lines in nameFile:                      # 读取行
     curLine = nameFile.readline()
 
-    if not curLine:
+    if not curLine:                         # 若文件结束，退出循环
         continue
 
-    curLine = curLine.replace('\n', '')
-    lineContent = curLine.split('\t')
+    curLine = curLine.replace('\n', '')     # 以制表符为分隔符分割每行
+    lineContent = curLine.split('\t')       # 转为list
 
-    if(len(lineContent) != 2):
+    if(len(lineContent) != 2):              # 若当前行的列表长度不为2（乱七八糟别的东西）则下一行
         continue
     
-    if(is_contains_chinese(lineContent[0]) == True):
+    # 检测每行两个元素是否包含中文，并用flags列表标记
+    flags = [is_contains_chinese(lineContent[0]), is_contains_chinese(lineContent[1])]
+
+    if(flags == [True, False]):         # 第一个元素有中文，第二个没有
         cnList.append(lineContent[0])
         enList.append(lineContent[1])
-    else:
+    elif(flags == [False, True]):       # 第二个元素有中文，第一个没有
         cnList.append(lineContent[1])
         enList.append(lineContent[0])
+    else:                               # 其他情况，直接跳下一行
+        continue
 
-#dataNames = [enList, cnList]
-#print(len(dataNames[0]))
-#print(len(dataNames[1]))
+df = pd.DataFrame({'enName':enList, 'cnName':cnList})   # 转为pandas库的DataFrame
 
-df = pd.DataFrame({'enName':enList, 'cnName':cnList})
-
-df.to_csv("Translations.csv", index = False, sep = ',', encoding = 'utf-8-sig')
+df.to_csv("Translations.csv", index = False, sep = ',', encoding = 'utf-8-sig') # 按utf-8-sig编码写入csv，用Excel打开不乱码


### PR DESCRIPTION
添加txt转csv的python脚本，并有运行结果文件。
后续可以导入csv为python词典，可以进一步编写可互动的python脚本（例如输入英文名称返回中文名称）。