### PR TITLE
修正txt读取不完整问题，增加跳过的行内容的记录

### DIFF
--- a/txt转其他格式/Translations.csv
+++ b/txt转其他格式/Translations.csv
@@ -1,895 +1,1781 @@
 ﻿enName,cnName
+Acacia Button,金合欢木按钮
 Acacia Door,金合欢木门
+Acacia Fence,金合欢木栅栏
 Acacia Fence Gate,金合欢木栅栏门
+Acacia Leaves,金合欢树叶
 Acacia Log,金合欢原木
+Acacia Planks,金合欢木板
 Acacia Pressure Plate,金合欢木压力板
+Acacia Sapling,金合欢树苗
 Acacia Sign,金合欢木告示牌
+Acacia Slab,金合欢木台阶
 Acacia Stairs,金合欢木楼梯
+Acacia Trapdoor,金合欢木活板门
 Acacia Wall Sign,墙上的金合欢木告示牌
+Acacia Wood,金合欢木
 Activator Rail,激活铁轨
+Air,空气
 Allium,绒球葱
+Amethyst Bud,紫晶芽
 Amethyst Cluster,紫水晶簇
+Ancient Debris,远古残骸
 Andesite,安山岩
+Andesite Slab,安山岩台阶
 Andesite Stairs,安山岩楼梯
+Andesite Wall,安山岩墙
 Anvil,铁砧
+Attached Melon Stem,结果的西瓜茎
 Attached Pumpkin Stem,结果的南瓜茎
+Azalea,杜鹃花丛
 Azalea Leaves,杜鹃树叶
+Azure Bluet,蓝花美耳草
 Bamboo Sapling,竹笋
+Bamboo Shoot,竹笋
 Banner,旗帜
+Barrel,木桶
 Barrier,屏障
+Basalt,玄武岩
 Beacon,信标
+Bed,床
 Bedrock,基岩
+Bee Nest,蜂巢
 Beehive,蜂箱
+Beetroots,甜菜根
 Bell,钟
+Big Dripleaf,大型垂滴叶
 Big Dripleaf Stem,大型垂滴叶茎
+Birch Button,白桦木按钮
 Birch Door,白桦木门
+Birch Fence,白桦木栅栏
 Birch Fence Gate,白桦木栅栏门
+Birch Leaves,白桦树叶
 Birch Log,白桦原木
+Birch Planks,白桦木板
 Birch Pressure Plate,白桦木压力板
+Birch Sapling,白桦树苗
 Birch Sign,白桦木告示牌
+Birch Slab,白桦木台阶
 Birch Stairs,白桦木楼梯
+Birch Trapdoor,白桦木活板门
 Birch Wall Sign,墙上的白桦木告示牌
+Birch Wood,白桦木
 Black Wall Banner,墙上的黑色旗帜
+Blackstone,黑石
 Blackstone Slab,黑石台阶
+Blackstone Stairs,黑石楼梯
 Blackstone Wall,黑石墙
+Blast Furnace,高炉
 Block of Amethyst,紫水晶块
+Block of Coal,煤炭块
 Block of Copper,铜块
+Block of Diamond,钻石块
 Block of Emerald,绿宝石块
+Block of Gold,金块
 Block of Iron,铁块
+Block of Lapis Lazuli,青金石块
 Block of Netherite,下界合金块
+Block of Quartz,石英块
 Block of Raw Copper,粗铜块
+Block of Raw Gold,粗金块
 Block of Raw Iron,粗铁块
+Block of Redstone,红石块
 Blue Ice,蓝冰
+Blue Orchid,兰花
 Blue Wall Banner,墙上的蓝色旗帜
+Bone Block,骨块
 Bookshelf,书架
+Brain Coral,脑纹珊瑚
 Brain Coral Block,脑纹珊瑚块
+Brain Coral Fan,脑纹珊瑚扇
 Brain Coral Wall Fan,墙上的脑纹珊瑚扇
+Brewing Stand,酿造台
 Brick Slab,砖台阶
+Brick Stairs,砖楼梯
 Brick Wall,砖块墙
+Bricks,砖块
 Brown Mushroom,棕色蘑菇
+Brown Mushroom Block,棕色蘑菇方块
 Brown Wall Banner,墙上的棕色旗帜
+Bubble Column,气泡柱
 Bubble Coral,气泡珊瑚
+Bubble Coral Block,气泡珊瑚块
 Bubble Coral Fan,气泡珊瑚扇
+Bubble Coral Wall Fan,墙上的气泡珊瑚扇
 Budding Amethyst,紫水晶母岩
+Button,按钮
 Cactus,仙人掌
+Cake,蛋糕
 Cake With Black Candle,插上黑色蜡烛的蛋糕
+Cake With Blue Candle,插上蓝色蜡烛的蛋糕
 Cake With Brown Candle,插上棕色蜡烛的蛋糕
+Cake With Candle,插上蜡烛的蛋糕
 Cake With Cyan Candle,插上青色蜡烛的蛋糕
+Cake With Gray Candle,插上灰色蜡烛的蛋糕
 Cake With Green Candle,插上绿色蜡烛的蛋糕
+Cake With Light Blue Candle,插上淡蓝色蜡烛的蛋糕
 Cake With Light Gray Candle,插上淡灰色蜡烛的蛋糕
+Cake With Lime Candle,插上黄绿色蜡烛的蛋糕
 Cake With Magenta Candle,插上品红色蜡烛的蛋糕
+Cake With Orange Candle,插上橙色蜡烛的蛋糕
 Cake With Pink Candle,插上粉红色蜡烛的蛋糕
+Cake With Purple Candle,插上紫色蜡烛的蛋糕
 Cake With Red Candle,插上红色蜡烛的蛋糕
+Cake With White Candle,插上白色蜡烛的蛋糕
 Cake With Yellow Candle,插上黄色蜡烛的蛋糕
+Calcite,方解石
 Campfire,营火
+Candle Cake,插上蜡烛的蛋糕
 Carpet,地毯
+Carrots,胡萝卜
 Cartography Table,制图台
+Carved Pumpkin,雕刻过的南瓜
 Cauldron,炼药锅
+Cave Air,洞穴空气
 Cave Vines,洞穴藤蔓
+Cave Vines Plant,洞穴藤蔓植株
 Chain,锁链
+Chain Command Block,连锁型命令方块
 Chalkboard,黑板
+Chest,箱子
 Chipped Anvil,开裂的铁砧
+Chiseled Deepslate,錾制深板岩
 Chiseled Nether Bricks,錾制下界砖块
+Chiseled Polished Blackstone,錾制磨制黑石
 Chiseled Quartz Block,錾制石英块
+Chiseled Red Sandstone,錾制红砂岩
 Chiseled Sandstone,錾制砂岩
+Chiseled Stone Bricks,錾制石砖
 Chorus Flower,紫颂花
+Chorus Plant,紫颂植株
 Clay,黏土块
+Coal Ore,煤矿石
 Coarse Dirt,砂土
+Cobbled Deepslate,深板岩圆石
 Cobbled Deepslate Slab,深板岩圆石台阶
+Cobbled Deepslate Stairs,深板岩圆石楼梯
 Cobbled Deepslate Wall,深板岩圆石墙
+Cobblestone,圆石
 Cobblestone Slab,圆石台阶
+Cobblestone Stairs,圆石楼梯
 Cobblestone Wall,圆石墙
+Cobweb,蜘蛛网
 Cocoa,可可果
+Cog,齿轮
 Colored Terracotta,染色陶瓦
+Colored Wood Planks,染色木板
 Command Block,命令方块
+Composter,堆肥桶
 Concrete,混凝土
+Concrete Powder,混凝土粉末
 Conduit,潮涌核心
+Copper Ore,铜矿石
 Coral,珊瑚
+Coral Block,珊瑚块
 Coral Blocks,珊瑚块
+Coral Fan,珊瑚扇
 Coral Fans,珊瑚扇
+Cornflower,矢车菊
 Cracked Deepslate Bricks,裂纹深板岩砖
+Cracked Deepslate Tiles,裂纹深板岩瓦
 Cracked Nether Bricks,裂纹下界砖块
+Cracked Polished Blackstone Bricks,裂纹磨制黑石砖
 Cracked Stone Bricks,裂纹石砖
+Crafting Table,工作台
 Creeper Head,苦力怕的头
+Creeper Wall Head,墙上的苦力怕头颅
 Crimson Button,绯红木按钮
+Crimson Door,绯红木门
 Crimson Fence,绯红木栅栏
+Crimson Fence Gate,绯红木栅栏门
 Crimson Fungus,绯红菌
+Crimson Hyphae,绯红菌核
 Crimson Nylium,绯红菌岩
+Crimson Planks,绯红木板
 Crimson Pressure Plate,绯红木压力板
+Crimson Roots,绯红菌索
 Crimson Sign,绯红木告示牌
+Crimson Slab,绯红木台阶
 Crimson Stairs,绯红木楼梯
+Crimson Stem,绯红菌柄
 Crimson Trapdoor,绯红木活板门
+Crimson Wall Sign,墙上的绯红木告示牌
 Crying Obsidian,哭泣的黑曜石
+Cut Copper,切制铜块
 Cut Copper Slab,切制铜台阶
+Cut Copper Stairs,切制铜楼梯
 Cut Red Sandstone,切制红砂岩
+Cut Red Sandstone Slab,切制红砂岩台阶
 Cut Sandstone,切制砂岩
+Cut Sandstone Slab,切制砂岩台阶
 Cyan Flower,青花
+Cyan Wall Banner,墙上的青色旗帜
 Damaged Anvil,损坏的铁砧
+Dandelion,蒲公英
 Dark Oak Button,深色橡木按钮
+Dark Oak Door,深色橡木门
 Dark Oak Fence,深色橡木栅栏
+Dark Oak Fence Gate,深色橡木栅栏门
 Dark Oak Leaves,深色橡树树叶
+Dark Oak Log,深色橡木原木
 Dark Oak Planks,深色橡木木板
+Dark Oak Pressure Plate,深色橡木压力板
 Dark Oak Sapling,深色橡树树苗
+Dark Oak Sign,深色橡木告示牌
 Dark Oak Slab,深色橡木台阶
+Dark Oak Stairs,深色橡木楼梯
 Dark Oak Trapdoor,深色橡木活板门
+Dark Oak Wall Sign,墙上的深色橡木告示牌
 Dark Oak Wood,深色橡木
+Dark Prismarine,暗海晶石
 Dark Prismarine Slab,暗海晶石台阶
+Dark Prismarine Stairs,暗海晶石楼梯
 Daylight Detector,阳光探测器
+Daylight Sensor,阳光探测器
 Dead Brain Coral,失活的脑纹珊瑚
+Dead Brain Coral Block,失活的脑纹珊瑚块
 Dead Brain Coral Fan,失活的脑纹珊瑚扇
+Dead Brain Coral Wall Fan,墙上的失活脑纹珊瑚扇
 Dead Bubble Coral,失活的气泡珊瑚
+Dead Bubble Coral Block,失活的气泡珊瑚块
 Dead Bubble Coral Fan,失活的气泡珊瑚扇
+Dead Bubble Coral Wall Fan,墙上的失活气泡珊瑚扇
 Dead Bush,枯萎的灌木
+Dead Coral,失活的珊瑚
 Dead Coral Blocks,失活的珊瑚块
+Dead Coral Fans,失活的珊瑚扇
 Dead Fire Coral,失活的火珊瑚
+Dead Fire Coral Block,失活的火珊瑚块
 Dead Fire Coral Fan,失活的火珊瑚扇
+Dead Fire Coral Wall Fan,墙上的失活火珊瑚扇
 Dead Horn Coral,失活的鹿角珊瑚
+Dead Horn Coral Block,失活的鹿角珊瑚块
 Dead Horn Coral Fan,失活的鹿角珊瑚扇
+Dead Horn Coral Wall Fan,墙上的失活鹿角珊瑚扇
 Dead Tube Coral,失活的管珊瑚
+Dead Tube Coral Block,失活的管珊瑚块
 Dead Tube Coral Fan,失活的管珊瑚扇
+Dead Tube Coral Wall Fan,墙上的失活管珊瑚扇
 Deepslate,深板岩
+Deepslate Brick Slab,深板岩砖台阶
 Deepslate Brick Stairs,深板岩砖楼梯
+Deepslate Brick Wall,深板岩砖墙
 Deepslate Bricks,深板岩砖
+Deepslate Coal Ore,深层煤矿石
 Deepslate Copper Ore,深层铜矿石
+Deepslate Diamond Ore,深层钻石矿石
 Deepslate Emerald Ore,深层绿宝石矿石
+Deepslate Gold Ore,深层金矿石
 Deepslate Iron Ore,深层铁矿石
+Deepslate Lapis Lazuli Ore,深层青金石矿石
 Deepslate Lapis Ore,深层青金石矿石
+Deepslate Redstone Ore,深层红石矿石
 Deepslate Tile Slab,深板岩瓦台阶
+Deepslate Tile Stairs,深板岩瓦楼梯
 Deepslate Tile Wall,深板岩瓦墙
+Deepslate Tiles,深板岩瓦
 Detector Rail,探测铁轨
+Diamond Ore,钻石矿石
 Diorite,闪长岩
+Diorite Bell,闪长岩钟
 Diorite Slab,闪长岩台阶
+Diorite Stairs,闪长岩楼梯
 Diorite Wall,闪长岩墙
+Dirt,泥土
 Dirt Path,土径
+Dispenser,发射器
 Door,门
+Doors,门
 Dragon Egg,龙蛋
+Dragon Head,龙首
 Dragon Wall Head,墙上的龙首
+Dried Kelp Block,干海带块
 Dripstone Block,滴水石块
+Dropper,投掷器
 Dye,染料
+Dyed Bed,染色床
 Dyed Carpet,染色地毯
+Dyed Shulker Box,染色潜影盒
 Dyed Terracotta,染色陶瓦
+Dyed Wool,染色羊毛
 Emerald Ore,绿宝石矿石
+Empty Barrel,空木桶
 Enchanting Table,附魔台
+Enchantment Table,附魔台
 End Gateway,末地折跃门
+End Portal,末地传送门
 End Portal Frame,末地传送门框架
+End Rod,末地烛
 End Stone,末地石
+End Stone Brick Slab,末地石砖台阶
 End Stone Brick Stairs,末地石砖楼梯
+End Stone Brick Wall,末地石砖墙
 End Stone Bricks,末地石砖
+Ender Chest,末影箱
 Exposed Copper,斑驳的铜块
+Exposed Cut Copper,斑驳的切制铜块
 Exposed Cut Copper Slab,斑驳的切制铜台阶
+Exposed Cut Copper Stairs,斑驳的切制铜楼梯
 Fake Wood Slab,伪木台阶
+Farmland,耕地
 Fence,栅栏
+Fence Gate,栅栏门
 Fern,蕨
+Finished Nether Reactor Core,耗尽的下界反应核
 Fire,火
+Fire Coral,火珊瑚
 Fire Coral Block,火珊瑚块
+Fire Coral Fan,火珊瑚扇
 Fire Coral Wall Fan,墙上的火珊瑚扇
+Fish Barrel,鱼木桶
 Fletching Table,制箭台
+Flower,花
 Flower Pot,花盆
+Flowering Azalea,盛开的杜鹃花丛
 Flowering Azalea Leaves,盛开的杜鹃树叶
+Flowers,花
 Frog Spawn,青蛙卵
+Frosted Ice,霜冰
 Fungi,菌类
+Fungus,菌类
 Furnace,熔炉
+Furniture,家具
 Gilded Blackstone,镶金黑石
+Glass,玻璃
 Glass Pane,玻璃板
+Glazed Terracotta,带釉陶瓦
 Glow Lichen,发光地衣
+Glowstone,荧石
 Gold Ore,金矿石
+Granite,花岗岩
 Granite Bell,花岗岩钟
+Granite Slab,花岗岩台阶
 Granite Stairs,花岗岩楼梯
+Granite Wall,花岗岩墙
 Grass,草
+Grass Block,草方块
 Grass Path,草径
+Gravel,沙砾
 Gray Wall Banner,墙上的灰色旗帜
+Green Wall Banner,墙上的绿色旗帜
 Grindstone,砂轮
+Hanging Roots,垂根
 Hay Bale,干草块
+Head,生物头颅
 Heavy Weighted Pressure Plate,重质测重压力板
+Honey Block,蜂蜜块
 Honeycomb Block,蜜脾块
+Hopper,漏斗
 Horn Coral,鹿角珊瑚
+Horn Coral Block,鹿角珊瑚块
 Horn Coral Fan,鹿角珊瑚扇
+Horn Coral Wall Fan,墙上的鹿角珊瑚扇
 Huge Brown Mushroom,棕色巨型蘑菇
+Huge Mushrooms,巨型蘑菇
 Huge Red Mushroom,红色巨型蘑菇
+Hyphae,菌核
 Ice,冰
+Impulse Command Block,脉冲型命令方块
 Infested Block,被虫蚀的方块
+Infested Chiseled Stone Bricks,被虫蚀的錾制石砖
 Infested Cobblestone,被虫蚀的圆石
+Infested Cracked Stone Bricks,被虫蚀的裂纹石砖
 Infested Deepslate,被虫蚀的深板岩
+Infested Mossy Stone Bricks,被虫蚀的苔石砖
 Infested Stone,被虫蚀的石头
+Infested Stone Bricks,被虫蚀的石砖
 Initialized Nether Reactor Core,激活的下界反应核
+Inverted Daylight Detector,反向阳光探测器
 Inverted Daylight Sensor,反向阳光探测器
+Iron Bars,铁栏杆
 Iron Door,铁门
+Iron Ore,铁矿石
 Iron Trapdoor,铁活板门
+Jack O'lantern,南瓜灯
 Jigsaw Block,拼图方块
+Jukebox,唱片机
 Jungle Button,丛林木按钮
+Jungle Door,丛林木门
 Jungle Fence,丛林木栅栏
+Jungle Fence Gate,丛林木栅栏门
 Jungle Leaves,丛林树叶
+Jungle Log,丛林原木
 Jungle Planks,丛林木板
+Jungle Pressure Plate,丛林木压力板
 Jungle Sapling,丛林树苗
+Jungle Sign,丛林木告示牌
 Jungle Slab,丛林木台阶
+Jungle Stairs,丛林木楼梯
 Jungle Trapdoor,丛林木活板门
+Jungle Wall Sign,墙上的丛林木告示牌
 Jungle Wood,丛林木
+Kelp Plant,海带植株
 Ladder,梯子
+Lantern,灯笼
 Lapis Lazuli Block,青金石块
+Lapis Lazuli Ore,青金石矿石
 Large Amethyst Bud,大型紫晶芽
+Large Fern,大型蕨
 Lava,熔岩
+Lava Cauldron,装有熔岩的炼药锅
 Leaves,树叶
+Lectern,讲台
 Lever,拉杆
+Light,光
 Light 0,光
+Light 1,光
 Light 10,光
+Light 11,光
 Light 12,光
+Light 13,光
 Light 14,光
+Light 15,光
 Light 2,光
+Light 3,光
 Light 4,光
+Light 5,光
 Light 6,光
+Light 7,光
 Light 8,光
+Light 9,光
 Light Blue Wall Banner,墙上的淡蓝色旗帜
+Light Gray Wall Banner,墙上的淡灰色旗帜
 Light Negative,光
+Light Weighted Pressure Plate,轻质测重压力板
 Lightning Rod,避雷针
+Lilac,丁香
 Lily of The Valley,铃兰
+Lily Pad,睡莲
 Lime Wall Banner,墙上的黄绿色旗帜
+Lit Blast Furnace,燃烧中的高炉
 Lit Deepslate Redstone Ore,点亮的深层红石矿石
+Lit Furnace,燃烧中的熔炉
 Lit Redstone Lamp,点亮的红石灯
+Lit Redstone Ore,点亮的红石矿石
 Lit Smoker,燃烧中的烟熏炉
+Locked Chest,上锁的箱子
 Lodestone,磁石
+Log,原木
 Loom,织布机
+Magenta Wall Banner,墙上的品红色旗帜
 Magma Block,岩浆块
+Medium Amethyst Bud,中型紫晶芽
 Melon,西瓜
+Melon Stem,西瓜茎
 Mob Head,生物头颅
+Moss Block,苔藓块
 Moss Carpet,苔藓地毯
+Moss Stone,苔石
 Mossy Cobblestone,苔石
+Mossy Cobblestone Slab,苔石台阶
 Mossy Cobblestone Stairs,苔石楼梯
+Mossy Cobblestone Wall,苔石墙
 Mossy Stone Brick Slab,苔石砖台阶
+Mossy Stone Brick Stairs,苔石砖楼梯
 Mossy Stone Brick Wall,苔石砖墙
+Mossy Stone Bricks,苔石砖
 Moving Block,移动的方块
+Moving Piston,移动的活塞
 Mushroom,蘑菇
+Mushroom Block,蘑菇方块
 Mushroom Stem,蘑菇柄
+Mycelium,菌丝
 Nether Brick Fence,下界砖栅栏
+Nether Brick Slab,下界砖台阶
 Nether Brick Stairs,下界砖楼梯
+Nether Brick Wall,下界砖墙
 Nether Bricks,下界砖块
+Nether Gold Ore,下界金矿石
 Nether Planks,下界木板
+Nether Portal,下界传送门
 Nether Quartz Ore,下界石英矿石
+Nether Sprouts,下界苗
 Nether Wart,下界疣
+Nether Wart Block,下界疣块
 Nether Wood Fence,下界木质栅栏
+Nether Wood Slab,下界木质台阶
 Netherrack,下界岩
+Note Block,音符盒
 Nylium,菌岩
+Oak Button,橡木按钮
 Oak Door,橡木门
+Oak Fence,橡木栅栏
 Oak Fence Gate,橡木栅栏门
+Oak Leaves,橡树树叶
 Oak Log,橡木原木
+Oak Planks,橡木木板
 Oak Pressure Plate,橡木压力板
+Oak Sapling,橡树树苗
 Oak Sign,橡木告示牌
+Oak Slab,橡木台阶
 Oak Stairs,橡木楼梯
+Oak Trapdoor,橡木活板门
 Oak Wall Sign,墙上的橡木告示牌
+Oak Wood,橡木
 Observer,侦测器
+Obsidian,黑曜石
 Ominous Banner,灾厄旗帜
+Orange Tulip,橙色郁金香
 Orange Wall Banner,墙上的橙色旗帜
+Overworld Log,主世界原木
 Overworld Planks,主世界木板
+Overworld Stripped Log,主世界去皮原木
 Overworld Stripped Wood,主世界去皮木头
+Overworld Wood,主世界木头
 Overworld Wood Fence,主世界木质栅栏
+Overworld Wood Slab,主世界木质台阶
 Oxeye Daisy,滨菊
+Oxidized Copper,氧化的铜块
 Oxidized Cut Copper,氧化的切制铜块
+Oxidized Cut Copper Slab,氧化的切制铜台阶
 Oxidized Cut Copper Stairs,氧化的切制铜楼梯
+Packed Ice,浮冰
 Peony,牡丹
+Petrified Oak Slab,石化橡木台阶
 Pink Tulip,粉红色郁金香
+Pink Wall Banner,墙上的粉红色旗帜
 Piston,活塞
+Piston Head,活塞头
 Plank,木板
+Player Head,玩家头颅
 Player Wall Head,墙上的玩家头颅
+Podzol,灰化土
 Pointed Dripstone,滴水石锥
+Polished Andesite,磨制安山岩
 Polished Andesite Slab,磨制安山岩台阶
+Polished Andesite Stairs,磨制安山岩楼梯
 Polished Basalt,磨制玄武岩
+Polished Blackstone,磨制黑石
 Polished Blackstone Brick Slab,磨制黑石砖台阶
+Polished Blackstone Brick Stairs,磨制黑石砖楼梯
 Polished Blackstone Brick Wall,磨制黑石砖墙
+Polished Blackstone Bricks,磨制黑石砖
 Polished Blackstone Button,磨制黑石按钮
+Polished Blackstone Pressure Plate,磨制黑石压力板
 Polished Blackstone Slab,磨制黑石台阶
+Polished Blackstone Stairs,磨制黑石楼梯
 Polished Blackstone Wall,磨制黑石墙
+Polished Deepslate,磨制深板岩
 Polished Deepslate Slab,磨制深板岩台阶
+Polished Deepslate Stairs,磨制深板岩楼梯
 Polished Deepslate Wall,磨制深板岩墙
+Polished Diorite,磨制闪长岩
 Polished Diorite Slab,磨制闪长岩台阶
+Polished Diorite Stairs,磨制闪长岩楼梯
 Polished Granite,磨制花岗岩
+Polished Granite Bell,磨制花岗岩钟
 Polished Granite Slab,磨制花岗岩台阶
+Polished Granite Stairs,磨制花岗岩楼梯
 Poppy,虞美人
+Potatoes,马铃薯
 Potted Acacia Sapling,金合欢树苗盆栽
+Potted Allium,绒球葱盆栽
 Potted Azalea,杜鹃花丛盆栽
+Potted Azure Bluet,蓝花美耳草盆栽
 Potted Bamboo,竹子盆栽
+Potted Birch Sapling,白桦树苗盆栽
 Potted Blue Orchid,兰花盆栽
+Potted Brown Mushroom,棕色蘑菇盆栽
 Potted Cactus,仙人掌盆栽
+Potted Cornflower,矢车菊盆栽
 Potted Crimson Fungus,绯红菌盆栽
+Potted Crimson Roots,绯红菌索盆栽
 Potted Dandelion,蒲公英盆栽
+Potted Dark Oak Sapling,深色橡树树苗盆栽
 Potted Dead Bush,枯萎的灌木盆栽
+Potted Fern,蕨盆栽
 Potted Flowering Azalea,盛开的杜鹃花丛盆栽
+Potted Jungle Sapling,丛林树苗盆栽
 Potted Lily of The Valley,铃兰盆栽
+Potted Oak Sapling,橡树树苗盆栽
 Potted Orange Tulip,橙色郁金香盆栽
+Potted Oxeye Daisy,滨菊盆栽
 Potted Pink Tulip,粉红色郁金香盆栽
+Potted Poppy,虞美人盆栽
 Potted Red Mushroom,红色蘑菇盆栽
+Potted Red Tulip,红色郁金香盆栽
 Potted Spruce Sapling,云杉树苗盆栽
+Potted Warped Fungus,诡异菌盆栽
 Potted Warped Roots,诡异菌索盆栽
+Potted White Tulip,白色郁金香盆栽
 Potted Wither Rose,凋零玫瑰盆栽
+Powder Snow,细雪
 Powder Snow Cauldron,装有细雪的炼药锅
+Powered Rail,动力铁轨
 Powered Redstone Comparator,激活的红石比较器
+Powered Redstone Repeater,激活的红石中继器
 Pressure Plate,压力板
+Prismarine,海晶石
 Prismarine Brick Slab,海晶石砖台阶
+Prismarine Brick Stairs,海晶石砖楼梯
 Prismarine Bricks,海晶石砖
+Prismarine Slab,海晶石台阶
 Prismarine Stairs,海晶石楼梯
+Prismarine Wall,海晶石墙
 Pumpkin,南瓜
+Pumpkin Stem,南瓜茎
 Purple Wall Banner,墙上的紫色旗帜
+Purpur Block,紫珀块
 Purpur Pillar,紫珀柱
+Purpur Slab,紫珀台阶
 Purpur Stairs,紫珀楼梯
+Quartz Block,石英块
 Quartz Bricks,石英砖
+Quartz Pillar,石英柱
 Quartz Slab,石英台阶
+Quartz Stairs,石英楼梯
 Rail,铁轨
+Red Mushroom,红色蘑菇
 Red Mushroom Block,红色蘑菇方块
+Red Nether Brick Slab,红色下界砖台阶
 Red Nether Brick Stairs,红色下界砖楼梯
+Red Nether Brick Wall,红色下界砖墙
 Red Nether Bricks,红色下界砖块
+Red Sand,红沙
 Red Sandstone,红砂岩
+Red Sandstone Slab,红砂岩台阶
 Red Sandstone Stairs,红砂岩楼梯
+Red Sandstone Wall,红砂岩墙
 Red Tulip,红色郁金香
+Red Wall Banner,墙上的红色旗帜
 Redstone Comparator,红石比较器
+Redstone Lamp,红石灯
 Redstone Ore,红石矿石
+Redstone Repeater,红石中继器
 Redstone Torch,红石火把
+Redstone Wall Torch,墙上的红石火把
 Redstone Wire,红石线
+Repeating Command Block,循环型命令方块
 Respawn Anchor,重生锚
+Rooted Dirt,缠根泥土
 Roots,菌索
+Rose,玫瑰
 Rose Bush,玫瑰丛
+Sand,沙子
 Sandstone,砂岩
+Sandstone Slab,砂岩台阶
 Sandstone Stairs,砂岩楼梯
+Sandstone Wall,砂岩墙
 Sapling,树苗
+Scaffolding,脚手架
 Sea Lantern,海晶灯
+Sea Pickle,海泡菜
 Seagrass,海草
+Shroomlight,菌光体
 Shulker Box,潜影盒
+Sign,告示牌
 Skeleton Skull,骷髅头颅
+Skeleton Wall Skull,墙上的骷髅头颅
 Slab,台阶
+Slabs,台阶
 Slightly Damaged Anvil,轻微损坏的铁砧
+Slime Block,黏液块
 Small Amethyst Bud,小型紫晶芽
+Small Dripleaf,小型垂滴叶
 Smithing Table,锻造台
+Smoker,烟熏炉
 Smooth Basalt,平滑玄武岩
+Smooth Quartz,平滑石英块
 Smooth Quartz Block,平滑石英块
+Smooth Quartz Slab,平滑石英台阶
 Smooth Quartz Stairs,平滑石英楼梯
+Smooth Red Sandstone,平滑红砂岩
 Smooth Red Sandstone Slab,平滑红砂岩台阶
+Smooth Red Sandstone Stairs,平滑红砂岩楼梯
 Smooth Sandstone,平滑砂岩
+Smooth Sandstone Slab,平滑砂岩台阶
 Smooth Sandstone Stairs,平滑砂岩楼梯
+Smooth Stone,平滑石头
 Smooth Stone Slab,平滑石头台阶
+Snow,雪
 Snow Block,雪块
+Soul Campfire,灵魂营火
 Soul Fire,灵魂火
+Soul Lantern,灵魂灯笼
 Soul Sand,灵魂沙
+Soul Soil,灵魂土
 Soul Torch,灵魂火把
+Soul Wall Torch,墙上的灵魂火把
 Spawner,刷怪笼
+Sponge,海绵
 Spore Blossom,孢子花
+Spruce Button,云杉木按钮
 Spruce Door,云杉木门
+Spruce Fence,云杉木栅栏
 Spruce Fence Gate,云杉木栅栏门
+Spruce Leaves,云杉树叶
 Spruce Log,云杉原木
+Spruce Planks,云杉木板
 Spruce Pressure Plate,云杉木压力板
+Spruce Sapling,云杉树苗
 Spruce Sign,云杉木告示牌
+Spruce Slab,云杉木台阶
 Spruce Stairs,云杉木楼梯
+Spruce Trapdoor,云杉木活板门
 Spruce Wall Sign,墙上的云杉木告示牌
+Spruce Wood,云杉木
 Stained Glass,染色玻璃
+Stained Glass Pane,染色玻璃板
 Stairs,楼梯
+Stem,菌柄
 Sticky Piston,黏性活塞
+Stone,石头
 Stone Brick Slab,石砖台阶
+Stone Brick Stairs,石砖楼梯
 Stone Brick Wall,石砖墙
+Stone Bricks,石砖
 Stone Bricks Slab,石砖台阶
+Stone Button,石头按钮
 Stone Pressure Plate,石头压力板
+Stone Slab,石头台阶
 Stone Stairs,石头楼梯
+Stone Tier Block,类圆石方块
 Stonecutter,切石机
+Stripped Acacia Log,去皮金合欢原木
 Stripped Acacia Wood,去皮金合欢木
+Stripped Birch Log,去皮白桦原木
 Stripped Birch Wood,去皮白桦木
+Stripped Crimson Hyphae,去皮绯红菌核
 Stripped Crimson Stem,去皮绯红菌柄
+Stripped Dark Oak Log,去皮深色橡木原木
 Stripped Dark Oak Wood,去皮深色橡木
+Stripped Hyphae,去皮菌核
 Stripped Jungle Log,去皮丛林原木
+Stripped Jungle Wood,去皮丛林木
 Stripped Log,去皮原木
+Stripped Oak Log,去皮橡木原木
 Stripped Oak Wood,去皮橡木
+Stripped Spruce Log,去皮云杉原木
 Stripped Spruce Wood,去皮云杉木
+Stripped Stem,去皮菌柄
 Stripped Warped Hyphae,去皮诡异菌核
+Stripped Warped Stem,去皮诡异菌柄
 Stripped Wood,去皮木头
+Structure Block,结构方块
 Structure Void,结构空位
+Sugar Cane,甘蔗
 Sunflower,向日葵
+Sweet Berry Bush,甜浆果丛
 Tall Grass,高草丛
+Tall Seagrass,高海草
 Target,标靶
+Terracotta,陶瓦
 Tinted Glass,遮光玻璃
 Torch,火把
+Trapdoor,活板门
 Trapped Chest,陷阱箱
+Tripwire,绊线
 Tripwire Hook,绊线钩
+Tube Coral,管珊瑚
 Tube Coral Block,管珊瑚块
+Tube Coral Fan,管珊瑚扇
 Tube Coral Wall Fan,墙上的管珊瑚扇
+Tuff,凝灰岩
 Tulips,郁金香
+Turtle Egg,海龟蛋
 Twisting Vines,缠怨藤
+Twisting Vines Plant,缠怨藤植株
 Unlit Redstone Torch,熄灭的红石火把
+Unpowered Redstone Comparator,未激活的红石比较器
 Unpowered Redstone Repeater,未激活的红石中继器
+Very Damaged Anvil,严重损坏的铁砧
 Vines,藤蔓
+Void Air,虚空空气
 Wall,墙
+Wall Banner,墙上的旗帜
 Wall Torch,墙上的火把
+Warped Button,诡异木按钮
 Warped Door,诡异木门
+Warped Fence,诡异木栅栏
 Warped Fence Gate,诡异木栅栏门
+Warped Fungus,诡异菌
 Warped Hyphae,诡异菌核
+Warped Nylium,诡异菌岩
 Warped Planks,诡异木板
+Warped Pressure Plate,诡异木压力板
 Warped Roots,诡异菌索
+Warped Sign,诡异木告示牌
 Warped Slab,诡异木台阶
+Warped Stairs,诡异木楼梯
 Warped Stem,诡异菌柄
+Warped Trapdoor,诡异木活板门
 Warped Wall Sign,墙上的诡异木告示牌
+Warped Wart Block,诡异疣块
 Water,水
+Water Cauldron,装有水的炼药锅
 Wax Block,蜂蜡块
+Waxed Block of Copper,涂蜡铜块
 Waxed Cut Copper,涂蜡切制铜块
+Waxed Cut Copper Slab,涂蜡切制铜台阶
 Waxed Cut Copper Stairs,涂蜡切制铜楼梯
+Waxed Exposed Copper,斑驳的涂蜡铜块
 Waxed Exposed Cut Copper,斑驳的涂蜡切制铜块
+Waxed Exposed Cut Copper Slab,斑驳的涂蜡切制铜台阶
 Waxed Exposed Cut Copper Stairs,斑驳的涂蜡切制铜楼梯
+Waxed Oxidized Copper,氧化的涂蜡铜块
 Waxed Oxidized Cut Copper,氧化的涂蜡切制铜块
+Waxed Oxidized Cut Copper Slab,氧化的涂蜡切制铜台阶
 Waxed Oxidized Cut Copper Stairs,氧化的涂蜡切制铜楼梯
+Waxed Weathered Copper,锈蚀的涂蜡铜块
 Waxed Weathered Cut Copper,锈蚀的涂蜡切制铜块
+Waxed Weathered Cut Copper Slab,锈蚀的涂蜡切制铜台阶
 Waxed Weathered Cut Copper Stairs,锈蚀的涂蜡切制铜楼梯
+Weathered Copper,锈蚀的铜块
 Weathered Cut Copper,锈蚀的切制铜块
+Weathered Cut Copper Slab,锈蚀的切制铜台阶
 Weathered Cut Copper Stairs,锈蚀的切制铜楼梯
+Weeping Vines,垂泪藤
 Weeping Vines Plant,垂泪藤植株
+Weighted Pressure Plate,测重压力板
 Wet Sponge,湿海绵
+Wheat,小麦
 Wheat Crops,小麦
+White Tulip,白色郁金香
 White Wall Banner,墙上的白色旗帜
+Wither Rose,凋零玫瑰
 Wither Skeleton Skull,凋灵骷髅头颅
+Wither Skeleton Wall Skull,墙上的凋灵骷髅头颅
 Wood,木头
+Wood Fence,木质栅栏
 Wood Slab,木质台阶
+Wood Stairs,木质楼梯
 Wooden Button,木质按钮
+Wooden Door,木门
 Wooden Fence,木质栅栏
+Wooden Planks,木板
 Wooden Pressure Plate,木质压力板
+Wooden Slab,木质台阶
 Wooden Stairs,木质楼梯
+Wooden Trapdoor,木质活板门
 Wool,羊毛
+Yellow Wall Banner,墙上的黄色旗帜
 Zombie Head,僵尸的头
+Zombie Wall Head,墙上的僵尸头颅
 Acacia Boat,金合欢木船
+Amethyst Shard,紫水晶碎片
 Apple,苹果
+Arrow,箭
 Arrow Loaded Crossbow,装填箭的弩
+Arrow of Decay,衰变之箭
 Arrow of Fire Resistance,抗火之箭
+Arrow of Harming,伤害之箭
 Arrow of Healing,治疗之箭
+Arrow of Invisibility,隐身之箭
 Arrow of Leaping,跳跃之箭
+Arrow of Luck,幸运之箭
 Arrow of Night Vision,夜视之箭
+Arrow of Poison,剧毒之箭
 Arrow of Regeneration,再生之箭
+Arrow of Slow Falling,缓降之箭
 Arrow of Slowness,迟缓之箭
+Arrow of Splashing,喷溅之箭
 Arrow of Strength,力量之箭
+Arrow of Swiftness,迅捷之箭
 Arrow of The Turtle Master,神龟之箭
+Arrow of Water Breathing,水肺之箭
 Arrow of Weakness,虚弱之箭
+Awkward Lingering Potion,滞留型粗制的药水
 Awkward Potion,粗制的药水
+Awkward Splash Potion,喷溅型粗制药水
 Axe,斧
+Baked Potato,烤马铃薯
 Bamboo,竹子
+Banner Pattern,旗帜图案
 Banner Pattern Bordure Indented,旗帜图案
+Banner Pattern Creeper,旗帜图案
 Banner Pattern Creeper Charge,旗帜图案
+Banner Pattern Field Masoned,旗帜图案
 Banner Pattern Flower,旗帜图案
+Banner Pattern Flower Charge,旗帜图案
 Banner Pattern Globe,旗帜图案
+Banner Pattern Piglin,旗帜图案
 Banner Pattern Skull,旗帜图案
+Banner Pattern Skull Charge,旗帜图案
 Banner Pattern Thing,旗帜图案
+Beetroot,甜菜根
 Beetroot Seeds,甜菜种子
+Beetroot Soup,甜菜汤
 Birch Boat,白桦木船
+Black Dye,黑色染料
 Blaze Powder,烈焰粉
+Blaze Rod,烈焰棒
 Blue Dye,蓝色染料
+Boat,船
 Bone,骨头
+Bone Meal,骨粉
 Book,书
+Book And Quill,书与笔
 Boots,靴子
+Bottle o' Enchanting,附魔之瓶
 Bow,弓
+Bowl,碗
 Bread,面包
+Brick,红砖
 Broken Elytra,破损的鞘翅
+Brown Dye,棕色染料
 Bucket,桶
+Bucket of Axolotl,美西螈桶
 Bucket of Cod,鳕鱼桶
+Bucket of Pufferfish,河豚桶
 Bucket of Salmon,鲑鱼桶
+Bucket of Tadpole,蝌蚪桶
 Bucket of Tropical Fish,热带鱼桶
+Bundle,收纳袋
 Buried Treasure Map,藏宝图
+Cactus Green,仙人掌绿
 Candle,蜡烛
+Carrot,胡萝卜
 Carrot On a Stick,胡萝卜钓竿
+Chainmail Armor,锁链盔甲
 Chainmail Boots,锁链靴子
+Chainmail Chestplate,锁链胸甲
 Chainmail Helmet,锁链头盔
+Chainmail Leggings,锁链护腿
 Charcoal,木炭
+Chestplate,胸甲
 Chorus Fruit,紫颂果
+Clay Ball,黏土球
 Clock,时钟
+Clownfish,小丑鱼
 Coal,煤炭
+Cocoa Beans,可可豆
 Cod Bucket,鳕鱼桶
+Colored Dye,染料
 Compass,指南针
+Cooked Beef,牛排
 Cooked Chicken,熟鸡肉
+Cooked Cod,熟鳕鱼
 Cooked Fish,熟鱼
+Cooked Mutton,熟羊肉
 Cooked Porkchop,熟猪排
+Cooked Rabbit,熟兔肉
 Cooked Salmon,熟鲑鱼
+Cookie,曲奇
 Copper Ingot,铜锭
+Crossbow,弩
 Crystallized Honey,结晶蜜
+Cyan Dye,青色染料
 Dandelion Yellow,蒲公英黄
+Dark Oak Boat,深色橡木船
 Debug Stick,调试棒
+Diamond,钻石
 Diamond Axe,钻石斧
+Diamond Boots,钻石靴子
 Diamond Chestplate,钻石胸甲
+Diamond Helmet,钻石头盔
 Diamond Hoe,钻石锄
+Diamond Horse Armor,钻石马铠
 Diamond Leggings,钻石护腿
+Diamond Pickaxe,钻石镐
 Diamond Shovel,钻石锹
+Diamond Sword,钻石剑
 Dragon's Breath,龙息
+Dried Kelp,干海带
 Egg,鸡蛋
+Elytra,鞘翅
 Emerald,绿宝石
+Empty Locator Map,空定位器地图
 Empty Map,空地图
+Enchanted Book,附魔书
 Enchanted Golden Apple,附魔金苹果
+End Crystal,末影水晶
 Ender Pearl,末影珍珠
+Explorer Map,探险家地图
 Eye of Ender,末影之眼
+Feather,羽毛
 Fermented Spider Eye,发酵蛛眼
+Filled Bundle,收纳袋
 Filled Map,地图
+Fire Charge,火焰弹
 Firework Loaded Crossbow,装填烟花的弩
+Firework Rocket,烟花火箭
 Firework Star,烟火之星
+Fish,鱼
 Fishing Rod,钓鱼竿
+Flint,燧石
 Flint And Steel,打火石
+Fuel,燃料
 Ghast Tear,恶魂之泪
+Glass Bottle,玻璃瓶
 Glistering Melon,闪烁的西瓜片
+Glistering Melon Slice,闪烁的西瓜片
 Glow Berries,发光浆果
+Glow Ink Sac,荧光墨囊
 Glow Item Frame,荧光物品展示框
+Glowstone Dust,荧石粉
 Goat Horn,山羊角
+Gold Ingot,金锭
 Gold Nugget,金粒
+Golden Apple,金苹果
 Golden Armor,金质盔甲
+Golden Axe,金斧
 Golden Boots,金靴子
+Golden Carrot,金胡萝卜
 Golden Chestplate,金胸甲
+Golden Helmet,金头盔
 Golden Hoe,金锄
+Golden Horse Armor,金马铠
 Golden Leggings,金护腿
+Golden Pickaxe,金镐
 Golden Shovel,金锹
+Golden Sword,金剑
 Golden Tools,金质工具
+Gray Dye,灰色染料
 Green Dye,绿色染料
+Gunpowder,火药
 Half Filled Bundle,收纳袋
+Heart of The Sea,海洋之心
 Helmet,头盔
+Hoe,锄
 Honey Bottle,蜂蜜瓶
+Honeycomb,蜜脾
 Horse Armor,马铠
+Ink Sac,墨囊
 Iron Armor,铁质盔甲
+Iron Axe,铁斧
 Iron Boots,铁靴子
+Iron Chestplate,铁胸甲
 Iron Helmet,铁头盔
+Iron Hoe,铁锄
 Iron Horse Armor,铁马铠
+Iron Ingot,铁锭
 Iron Leggings,铁护腿
+Iron Nugget,铁粒
 Iron Pickaxe,铁镐
+Iron Shovel,铁锹
 Iron Sword,铁剑
+Iron Tools,铁质工具
 Item Frame,物品展示框
+Jungle Boat,丛林木船
 Kelp,海带
+Knowledge Book,知识之书
 Lapis Lazuli,青金石
+Lava Bucket,熔岩桶
 Lead,拴绳
+Leather,皮革
 Leather Armor,皮革盔甲
+Leather Boots,皮革靴子
 Leather Cap,皮革帽子
+Leather Horse Armor,皮革马铠
 Leather Pants,皮革裤子
+Leather Tunic,皮革外套
 Leggings,护腿
+Light Blue Dye,淡蓝色染料
 Light Gray Dye,淡灰色染料
+Lime Dye,黄绿色染料
 Lingering Potion,滞留药水
+Lingering Potion of Decay,滞留型衰变药水
 Lingering Potion of Fire Resistance,滞留型抗火药水
+Lingering Potion of Harming,滞留型伤害药水
 Lingering Potion of Healing,滞留型治疗药水
+Lingering Potion of Invisibility,滞留型隐身药水
 Lingering Potion of Leaping,滞留型跳跃药水
+Lingering Potion of Luck,滞留型幸运药水
 Lingering Potion of Night Vision,滞留型夜视药水
+Lingering Potion of Poison,滞留型剧毒药水
 Lingering Potion of Regeneration,滞留型再生药水
+Lingering Potion of Slow Falling,滞留型缓降药水
 Lingering Potion of Slowness,滞留型迟缓药水
+Lingering Potion of Strength,滞留型力量药水
 Lingering Potion of Swiftness,滞留型迅捷药水
+Lingering Potion of The Turtle Master,滞留型神龟药水
 Lingering Potion of Water Breathing,滞留型水肺药水
+Lingering Potion of Weakness,滞留型虚弱药水
 Lingering Water Bottle,滞留型水瓶
+Locked Map,已锁定的地图
 Lodestone Compass,磁石指针
+Magenta Dye,品红色染料
 Magma Cream,岩浆膏
+Map,地图
 Melon Seeds,西瓜种子
+Melon Slice,西瓜片
 Milk Bucket,奶桶
+Minecart,矿车
 Minecart With Chest,运输矿车
+Minecart With Command Block,命令方块矿车
 Minecart With Dispenser,发射器矿车
+Minecart With Furnace,动力矿车
 Minecart With Hopper,漏斗矿车
+Minecart With Repeating Command Block,循环型命令方块矿车
 Minecart With Spawner,刷怪笼矿车
+Minecart With Tnt,TNT矿车
 Mundane Lingering Potion,滞留型平凡的药水
+Mundane Potion,平凡的药水
 Mundane Splash Potion,喷溅型平凡的药水
+Mushroom Stew,蘑菇煲
 Music Disc,音乐唱片
+Music Disc 11,音乐唱片
 Music Disc 13,音乐唱片
+Music Disc Blocks,音乐唱片
 Music Disc Cat,音乐唱片
+Music Disc Chirp,音乐唱片
 Music Disc Far,音乐唱片
+Music Disc Mall,音乐唱片
 Music Disc Mellohi,音乐唱片
+Music Disc Otherside,音乐唱片
 Music Disc Pigstep,音乐唱片
+Music Disc Stal,音乐唱片
 Music Disc Strad,音乐唱片
+Music Disc Wait,音乐唱片
 Music Disc Ward,音乐唱片
+Name Tag,命名牌
 Nautilus Shell,鹦鹉螺壳
+Nether Brick,下界砖
 Nether Quartz,下界石英
+Nether Star,下界之星
 Netherite Axe,下界合金斧
+Netherite Boots,下界合金靴子
 Netherite Chestplate,下界合金胸甲
+Netherite Helmet,下界合金头盔
 Netherite Hoe,下界合金锄
+Netherite Ingot,下界合金锭
 Netherite Leggings,下界合金护腿
+Netherite Pickaxe,下界合金镐
 Netherite Scrap,下界合金碎片
+Netherite Shovel,下界合金锹
 Netherite Sword,下界合金剑
+Oak Boat,橡木船
 Ocean Explorer Map,海洋探险家地图
+Orange Dye,橙色染料
 Painting,画
+Paper,纸
 Phantom Membrane,幻翼膜
+Pickaxe,镐
 Pink Dye,粉红色染料
+Poisonous Potato,毒马铃薯
 Popped Chorus Fruit,爆裂紫颂果
+Portfolio,公文包
 Potato,马铃薯
+Potion,药水
 Potion of Decay,衰变药水
+Potion of Fire Resistance,抗火药水
 Potion of Harming,伤害药水
+Potion of Healing,治疗药水
 Potion of Invisibility,隐身药水
+Potion of Leaping,跳跃药水
 Potion of Luck,幸运药水
+Potion of Night Vision,夜视药水
 Potion of Poison,剧毒药水
+Potion of Regeneration,再生药水
 Potion of Slow Falling,缓降药水
+Potion of Slowness,迟缓药水
 Potion of Strength,力量药水
+Potion of Swiftness,迅捷药水
 Potion of The Turtle Master,神龟药水
+Potion of Water Breathing,水肺药水
 Potion of Weakness,虚弱药水
+Powder Snow Bucket,细雪桶
 Prismarine Crystals,海晶砂粒
+Prismarine Shard,海晶碎片
 Pufferfish,河豚
+Pufferfish Bucket,河豚桶
 Pumpkin Pie,南瓜派
+Pumpkin Seeds,南瓜种子
 Purple Dye,紫色染料
+Rabbit Hide,兔子皮
 Rabbit Stew,兔肉煲
+Rabbit's Foot,兔子脚
 Raw Beef,生牛肉
+Raw Chicken,生鸡肉
 Raw Cod,生鳕鱼
+Raw Copper,粗铜
 Raw Fish,生鱼
+Raw Gold,粗金
 Raw Iron,粗铁
+Raw Mutton,生羊肉
 Raw Porkchop,生猪排
+Raw Rabbit,生兔肉
 Raw Salmon,生鲑鱼
+Red Dye,红色染料
 Redstone,红石粉
+Redstone Dust,红石粉
 Rose Red,玫瑰红
+Rotten Flesh,腐肉
 Saddle,鞍
+Salmon Bucket,鲑鱼桶
 Scute,鳞甲
+Seeds,种子
 Shears,剪刀
+Shield,盾牌
 Shovel,锹
+Shulker Shell,潜影壳
 Slimeball,黏液球
+Snowball,雪球
 Spawn Egg,刷怪蛋
+Spectral Arrow,光灵箭
 Spider Eye,蜘蛛眼
+Splash Awkward Potion,喷溅型粗制的药水
 Splash Mundane Potion,喷溅型平凡的药水
+Splash Potion,喷溅药水
 Splash Potion of Decay,喷溅型衰变药水
+Splash Potion of Fire Resistance,喷溅型抗火药水
 Splash Potion of Harming,喷溅型伤害药水
+Splash Potion of Healing,喷溅型治疗药水
 Splash Potion of Invisibility,喷溅型隐身药水
+Splash Potion of Leaping,喷溅型跳跃药水
 Splash Potion of Luck,喷溅型幸运药水
+Splash Potion of Night Vision,喷溅型夜视药水
 Splash Potion of Poison,喷溅型剧毒药水
+Splash Potion of Regeneration,喷溅型再生药水
 Splash Potion of Slow Falling,喷溅型缓降药水
+Splash Potion of Slowness,喷溅型迟缓药水
 Splash Potion of Strength,喷溅型力量药水
+Splash Potion of Swiftness,喷溅型迅捷药水
 Splash Potion of The Turtle Master,喷溅型神龟药水
+Splash Potion of Water Breathing,喷溅型水肺药水
 Splash Potion of Weakness,喷溅型虚弱药水
+Splash Water Bottle,喷溅型水瓶
 Spruce Boat,云杉木船
+Spyglass,望远镜
 Steak,牛排
+Stick,木棍
 Stone Axe,石斧
+Stone Hoe,石锄
 Stone Pickaxe,石镐
+Stone Shovel,石锹
 Stone Sword,石剑
+String,线
 Sugar,糖
+Suspicious Stew,迷之炖菜
 Sweet Berries,甜浆果
+Sword,剑
 Thick Lingering Potion,滞留型浓稠的药水
+Thick Potion,浓稠的药水
 Thick Splash Potion,喷溅型浓稠的药水
+Tipped Arrow,药箭
 Totem of Undying,不死图腾
+Trident,三叉戟
 Tropical Fish,热带鱼
+Tropical Fish Bucket,热带鱼桶
 Turtle Shell,海龟壳
+Uncraftable Lingering Potion,不可合成的滞留型药水
 Uncraftable Potion,不可合成的药水
+Uncraftable Splash Potion,不可合成的喷溅型药水
 Uncraftable Tipped Arrow,不可合成的药箭
+Undying Totem,不死图腾
 Warped Fungus On a Stick,诡异菌钓竿
+Water Bottle,水瓶
 Water Bucket,水桶
+Wheat,小麦
 Wheat Seeds,小麦种子
+White Dye,白色染料
 Wooden Axe,木斧
+Wooden Hoe,木锄
 Wooden Pickaxe,木镐
+Wooden Shovel,木锹
 Wooden Sword,木剑
+Woodland Explorer Map,林地探险家地图
 Written Book,成书
+Yellow Dye,黄色染料
 Agent,智能体
+Area Effect Cloud,区域效果云
 Armor Stand,盔甲架
+Axolotl,美西螈
 Bat,蝙蝠
+Bee,蜜蜂
 Black Cat,猫
+Blaze,烈焰人
 Brown Mooshroom,棕色哞菇
+Cat,猫
 Cave Spider,洞穴蜘蛛
+Charged Creeper,闪电苦力怕
 Chicken,鸡
+Chicken Jockey,鸡骑士
 Cod,鳕鱼
+Cow,牛
 Creeper,苦力怕
+Dolphin,海豚
 Donkey,驴
+Dragon Fireball,末影龙火球
 Drowned,溺尸
+Elder Guardian,远古守卫者
 Ender Crystal,末影水晶
+Ender Dragon,末影龙
 Enderman,末影人
+Endermite,末影螨
 Evoker,唤魔者
+Evoker Fangs,唤魔者尖牙
 Experience Orb,经验球
+Fireball,火球
 Fishing Bobber,浮漂
+Fox,狐狸
 Frog,青蛙
+Ghast,恶魂
 Giant,巨人
+Glow Squid,发光鱿鱼
 Goat,山羊
+Guardian,守卫者
 Hoglin,疣猪兽
+Horse,马
 Human,人类
+Husk,尸壳
 Illager,灾厄村民
+Illager Captain,灾厄队长
 Illusioner,幻术师
+Iron Golem,铁傀儡
 Item,物品
+Killer Bunny,杀手兔
 Leash Knot,拴绳结
+Lightning Bolt,闪电
 Llama,羊驼
+Llama Spit,羊驼唾沫
 Magma Cube,岩浆怪
+Marker,标记
+Mooshroom,哞菇
 Mule,骡
 Ocelot,豹猫
+Panda,熊猫
 Parrot,鹦鹉
+Phantom,幻翼
 Pig,猪
+Piglin,猪灵
 Piglin Brute,猪灵蛮兵
+Pigman,猪人
 Pillager,掠夺者
+Player,玩家
 Polar Bear,北极熊
+Pufferfish,河豚
 Rabbit,兔子
+Ravager,劫掠兽
 Red Cat,猫
+Red Mooshroom,红色哞菇
 Salmon,鲑鱼
+Sea Turtle,海龟
 Sheep,绵羊
+Shulker,潜影贝
 Shulker Bullet,潜影贝导弹
+Shulker Projectile,潜影贝导弹
 Siamese Cat,猫
+Silverfish,蠹虫
 Skeleton,骷髅
+Skeleton Horse,骷髅马
 Skeleton Horseman,骷髅骑手
+Slime,史莱姆
 Small Fireball,小火球
+Snow Golem,雪傀儡
 Spider,蜘蛛
+Spider Day,蜘蛛
 Spider Jockey,蜘蛛骑士
+Squid,鱿鱼
 Stray,流浪者
+Strider,炽足兽
 Tadpole,蝌蚪
+Tamed Wolf,驯服的狼
 Trader Llama,行商羊驼
+Tropical Fish,热带鱼
 Turtle,海龟
+Vex,恼鬼
 Villager,村民
+Vindicator,卫道士
 Wandering Trader,流浪商人
 Witch,女巫
+Wither,凋灵
 Wither Skeleton,凋灵骷髅
+Wither Skull,凋灵之首
 Wolf,狼
+Zoglin,僵尸疣猪兽
 Zombie,僵尸
+Zombie Horse,僵尸马
 Zombie Pigman,僵尸猪人
+Zombie Villager,僵尸村民
 Zombified Piglin,僵尸猪灵
+Protection,保护
 Fire Protection,火焰保护
+Feather Falling,摔落保护
 Blast Protection,爆炸保护
+Projectile Protection,弹射物保护
 Respiration,水下呼吸
+Aqua Affinity,水下速掘
 Thorns,荆棘
+Depth Strider,深海探索者
 Frost Walker,冰霜行者
+Curse of Binding,绑定诅咒
 Sharpness,锋利
+Smite,亡灵杀手
 Bane of Arthropods,节肢杀手
+Knockback,击退
 Fire Aspect,火焰附加
+Looting,抢夺
 Sweeping Edge,横扫之刃
+Efficiency,效率
 Silk Touch,精准采集
+Unbreaking,耐久
 Fortune,时运
+Power,力量
 Punch,冲击
+Flame,火矢
 Infinity,无限
+Luck of the Sea,海之眷顾
 Lure,饵钓
+Mending,经验修补
 Curse of Vanishing,消失诅咒
+Loyalty,忠诚
 Channeling,引雷
+Riptide,激流
 Impaling,穿刺
+Quick Charge,快速装填
 Multishot,多重射击
+Piercing,穿透
 Soul Speed,灵魂疾行
+Peaceful,和平
 Easy,简单
+Normal,普通
 Hard,困难
+Creative,创造模式
 Survival,生存模式
+Hardcore,极限模式
 Adventure,冒险模式
+Spectator,旁观模式
 Demo,演示模式（演示版）
+Survival Singleplayer （SSP）,单人生存模式
 Survival Multiplayer （SMP）,多人生存模式
+Creative Singleplayer （CSP）,单人创造模式
 Creative Multiplayer （CMP）,多人创造模式
+Hardcore Singleplayer （HSP）,单人极限模式
 Hardcore Multiplayer （HMP）,多人极限模式
+Adventure Singleplayer （ASP）,单人冒险模式
 Adventure Multiplayer （AMP）,多人冒险模式
+Splash,闪烁标语
 Accessibility,辅助功能
+Advancement,进度
 Attack indicator,攻击指示器
+Chest loot,箱子战利品
 Loot table,战利品表
+Crosshair,（十字）准星
 Heads-up display（HUD）,抬头显示器/平视显示器（常用HUD）
+Inventory,物品栏
 Hotbar,快捷栏
+Narrator,复述功能
 Slot,槽位
+Material,材料
 Renewable resource,可再生资源
+Rarity,稀有度
 Scoreboard,记分板
+Spawn,生成
 Status effect,状态效果
+Third person view,第三人称视角
 Waterlogging,含水
+Breaking,挖掘
 Breeding,繁殖
+Brewing,酿造
 Farming,耕种
+Crafting,合成
 Recipe book,配方书
+Enchanting,附魔
 Health,生命
+Health bar,生命条
 Hunger,饥饿
+Saturation level,饱和度
 Smelting,烧炼
+Trading,（村民）交易
 Blocking,防御
+Dual wield,双持
 Sneaking,潜行
+Sprinting,疾跑
 Transportation,运输
+Vehicle,载具（总称）
 Tutorial hint,教学提示
+Illager patrol,灾厄巡逻队
 Raid,袭击
+Tier,品质
 Mojang,（不翻译）
+Minecraft,（不翻译）
 Launcher,启动器
+Realms,（不翻译）
 Bedrock Edition,基岩版
+Education Edition,教育版
 Java Edition,Java版
+Legacy Console Edition,原主机版
 New Nintendo 3DS Edition,New Nintendo 3DS版
+Pocket Edition,携带版
 Version history,版本记录
+Development cycle,开发周期
 Upcoming,即将到来
+Planned version,计划版本
 Feature,特性（通用）
 Indev/Infdev/Alpha/Beta,（不翻译）
 Full release,正式版
+Snapshot,快照
 Pre-release,预发布版
+Build,开发版
 Mentioned feature,提及特性
+Removed feature,已移除特性
 Exclusive feature,独有特性
+Unused feature,未使用特性
 Easter egg,彩蛋
+Seecret Friday Update,秘密周五更新
 Adventure Update,冒险更新
+Pretty Scary Update,骇人更新
 Horse Update,马匹更新
+Bountful Update,缤纷更新
 Frostburn Update,霜炙更新
+Exploration Update,探险更新
 Colorful Update,多彩世界更新
+Update Aquatic,水域更新
 Village and Pillage,村庄与掠夺
+Buzzy Bees,嗡嗡蜂群
 Nether Update,下界更新
+Caves & Cliffs,洞穴与山崖
 Pocket Edition Alpha,携带版Alpha
+Pocket Edition Lite,携带版Lite
 Bedrock Edition alpha,基岩版alpha
+Bedrock Edition beta,基岩版beta
 Ender Update,末影更新
+Discovery Update,探索更新
 Better Together Update,独乐不如众乐更新
+Architecture,建筑
 Biome,生物群系
+Generated structure,结构
 Chunk,区块
+Feature,地物（地形特征）
 The Void,虚空
+World boundary,世界界限
 Projectile,弹射物
+Entity,实体
 Dimension,维度
+The Overworld,主世界
 The Nether,下界
+The End,末路之地（末地）
 Default,默认
+Amplified,放大化
 Superflat,超平坦
+Large biome,巨型生物群系
 Debug mode,调试模式
+Customized,自定义
 Buffet,自选
+Old,旧世界类型
 Floating island,浮岛
+Hollow,空洞
 Mountain,山脉
+Hill,丘陵
 Far Land,边境之地
+Abandoned mineshaft,废弃矿井
 Stronghold,要塞
+Buried treasure,埋藏的宝藏
 Dungeon,地牢
+Huge mushroom,巨型蘑菇
 Iceberg,冰山
+Ice spike,冰刺
 Mossy cobblestone boulder,生苔的巨石
+Shipwreck,沉船
 Coral reef,珊瑚礁
+Ocean monument,海底神殿
 Desert temple,沙漠神殿
+Jungle temple,丛林神庙
 Woodland mansion,林地府邸
+Pillager outpost,掠夺者前哨站
 Witch hut,沼泽小屋
+Glowstone cluster,荧石堆
 Lava sea,熔岩海
+Nether fortress,下界要塞
 End city,末地城
+Exit portal,返回传送门
 End gateway,末地折跃门
+Obsidian pillar,黑曜石柱
 Nether portal,下界传送门
+Conduit frame,潮涌框架
 Opacity,不透明度
+Ambient,环境音效
 Thunderstorm,雷暴
+Nether reactor,下界反应器
 Monolith,独石柱（暂译）
+Sky dimension,天域
 Enchanting library,附魔用图书馆
+Novice,新手
 Apprentice,学徒
+Journeyman,老手
 Expert,专家
+Master,大师
 Ocean ruins,海底废墟
+Igloo,雪屋
 Basalt pillar,玄武岩柱
+Ruined portal,废弃传送门
 Bastion remnant,堡垒遗迹
+Amethyst geode,紫晶洞
 Add-on,附加包
+Argument,变量
 Artifact,意外的……纹理、缺陷
+Asset,资源
 Block state（BS）,方块状态（通称BS）
+Boolean,布尔值（布尔型）
 Bug,漏洞
+Command,命令
 Common,普通（共通）
+Component,组件
 Crash,崩溃
+Data pack,数据包
 Data value（DV）,数据值（通称DV）
+Damage value,损害值
 Debug screen,调试界面
+Despawn,清除（消失）
 Dummy,虚拟型
+Field,字段
 Fixes,修复
+Format,格式
 Formatting code,格式化代码
+Flattening,扁平化
 Function,函数（功能）
+Generation,生成
 GUI,图形用户界面（通常不翻译）
+Hotfix,热修复
 ID,（不翻译）
+Interpret,解析
 Long,长整型
+Mash-up pack,混搭包
 Material,材质（定义渲染映射）
 Mob cap,生物容量
+Mod,（不翻译）
 Modify,修改
+Module,模块
 NBT,（不翻译）
+Option,选项
 Outdated,过期（过时）
+Parameter,参数
 Particle,粒子
+Placeholder,占位符
 Present,选定
+Range,范围
 Respawn,重生
+Screenshot,截屏
 Setting,设置
+Spawn chunk,出生点区块
 Spawn point,出生点
+Sprite,缩略图（精灵）
 String,字符串
+Syntax,语法
 Template,模板
+Texture,纹理
 Tick,刻
+Ticking area,常加载区域
 Tile,（不翻译）
+Toast notification,推送通知
 Added...,加入了……
+Addition,新内容
 Available,可用的
+Behavior,行为
 Chance,概率
+Changes,更改
 Destroy,摧毁
 Disambiguation,消歧义
+Gallery,画廊
 Gameplay,游戏内容
+General,常规
 Implement,实现
+Improve,改进
 Interwiki,跨Wiki链接（通常不翻译）
+Kill,杀死
 Label,标签
+Legend,图例
 Manufacture,人造
+Natural,自然
 Obtain,获取
+Performance,性能
 Redirect,重定向
+Reference,参考
 Release,发布
+Removed...,移除了……
 Sandbox,沙盒
+Scale,缩放
 See also,参见
+Size,大小
 Stack,堆叠数（组）
+Table,表格
 Trivia,你知道吗
+Utility,效用型
 Usage,用途（用法）
+Vanilla,原版
 Variant,变种
 Workplace,工作站点
 ocean,海洋
+plains,平原
 desert,沙漠
+windswept_hills,风袭丘陵
 forest,森林
+taiga,针叶林
 swamp,沼泽
+river,河流
 nether_wastes,下界荒地
+the_end,末地
 frozen_ocean,冻洋
+frozen_river,冻河
 snowy_plains,积雪的平原
+mushroom_fields,蘑菇岛
 beach,沙滩
+jungle,丛林
 sparse_jungle,稀疏的丛林
+deep_ocean,深海
 stony_shore,石岸
+snowy_beach,积雪的沙滩
 birch_forest,桦木森林
+dark_forest,黑森林
 snowy_taiga,积雪的针叶林
+old_growth_pine_taiga,原始松木针叶林
 windswept_forest,风袭森林
+savanna,热带草原
 savanna_plateau,热带高原
+badlands,恶地
 wooded_badlands,繁茂的恶地
+small_end_islands,末地小型岛屿
 end_midlands,末地中型岛屿
+end_highlands,末地高岛
 end_barrens,末地荒岛
+warm_ocean,暖水海洋
 lukewarm_ocean,温水海洋
+cold_ocean,冷水海洋
 deep_lukewarm_ocean,温水深海
+deep_cold_ocean,冷水深海
 deep_frozen_ocean,冰冻深海
+the_void,虚空
 sunflower_plains,向日葵平原
+windswept_gravelly_hills,风袭沙砾丘陵
 flower_forest,繁花森林
+ice_spikes,冰刺平原
 old_growth_birch_forest,原始桦木森林
+old_growth_spruce_taiga,原始云杉针叶林
 windswept_savanna,风袭热带草原
+eroded_badlands,被风蚀的恶地
 bamboo_jungle,竹林
+soul_sand_valley,灵魂沙峡谷
 crimson_forest,绯红森林
+warped_forest,诡异森林
 basalt_deltas,玄武岩三角洲
+dripstone_caves,溶洞
 lush_caves,繁茂洞穴
+meadow,草甸
 grove,雪林
+snowy_slopes,积雪的山坡
 frozen_peaks,冰封山峰
+jagged_peaks,尖峭山峰
 stony_peaks,裸岩山峰
+speed,速度
 slowness,缓慢
+haste,急迫
 mining_fatigue,挖掘疲劳
+strength,力量
 instant_health,瞬间治疗
+instant_damage,瞬间伤害
 jump_boost,跳跃提升
+nausea,反胃
 regeneration,生命恢复
+resistance,抗性提升
 fire_resistance,防火
+water_breathing,水下呼吸
 invisibility,隐身
+blindness,失明
 night_vision,夜视
+hunger,饥饿
 weakness,虚弱
+poison,中毒
 wither,凋零
+health_boost,生命提升
 absorption,伤害吸收
+saturation,饱和
 glowing,发光
+levitation,飘浮
 luck,幸运
+unluck,霉运
 slow_falling,缓降
+conduit_power,潮涌能量
 dolphins_grace,海豚的恩惠
+bad_omen,不祥之兆
 hero_of_the_village,村庄英雄

--- a/txt转其他格式/skipped_lines.txt
+++ b/txt转其他格式/skipped_lines.txt
@@ -1,1 +1,10 @@
+Tnt	TNT
 Mask	Mask
+Npc	NPC
+Warden	Warden
+Pre-classic/Classic/
+Official release/
+材料（其他义项）
+Disambig
+Job site
+//TO DO 修正中英顺序

--- a/txt转其他格式/skipped_lines.txt
+++ b/txt转其他格式/skipped_lines.txt
@@ -1,0 +1,1 @@
+Mask	Mask

--- a/txt转其他格式/txt-to-csv.py
+++ b/txt转其他格式/txt-to-csv.py
@@ -10,7 +10,9 @@ def is_contains_chinese(strs):
             return True
     return False
 
-nameFile = open('New_Recourse.txt', 'r', encoding = 'utf-8')    # 以UTF-8格式打开txt
+nameFile = open('New_Recourse.txt', 'r', encoding = 'utf-8')        # 以UTF-8格式打开txt
+skippedLines = open('skipped_lines.txt', 'w', encoding = 'utf-8')   # 新建一个txt保存跳过的行
+
 curLine = ''
 cnList = []
 enList = []
@@ -18,13 +20,14 @@ enList = []
 for lines in nameFile:                      # 读取行
     curLine = nameFile.readline()
 
-    if not curLine:                         # 若文件结束，退出循环
+    if not curLine:                         # 若为空行，则直接跳转到下一行
         continue
 
-    curLine = curLine.replace('\n', '')     # 以制表符为分隔符分割每行
-    lineContent = curLine.split('\t')       # 转为list
+    curLine = curLine.replace('\n', '')     # 去除换行符
+    lineContent = curLine.split('\t')       # 以制表符为分隔符分割每行并转为list
 
-    if(len(lineContent) != 2):              # 若当前行的列表长度不为2（乱七八糟别的东西）则下一行
+    if(len(lineContent) != 2):              # 若当前行的列表长度不为2（明显不是中文-英文或英文-中文格式）则输出当前行到文件并跳到下一行
+        skippedLines.write(curLine + '\n')  
         continue
     
     # 检测每行两个元素是否包含中文，并用flags列表标记
@@ -36,9 +39,14 @@ for lines in nameFile:                      # 读取行
     elif(flags == [False, True]):       # 第二个元素有中文，第一个没有
         cnList.append(lineContent[1])
         enList.append(lineContent[0])
-    else:                               # 其他情况，直接跳下一行
+    else:                               # 其他情况，输出当前行到文件并跳到下一行
+        skippedLines.write(curLine + '\n')
         continue
 
 df = pd.DataFrame({'enName':enList, 'cnName':cnList})   # 转为pandas库的DataFrame
 
 df.to_csv("Translations.csv", index = False, sep = ',', encoding = 'utf-8-sig') # 按utf-8-sig编码写入csv，用Excel打开不乱码
+
+# 关闭两个文件
+nameFile.close()
+skippedLines.close()

--- a/txt转其他格式/txt-to-csv.py
+++ b/txt转其他格式/txt-to-csv.py
@@ -17,8 +17,9 @@ curLine = ''
 cnList = []
 enList = []
 
-for lines in nameFile:                      # 读取行
-    curLine = nameFile.readline()
+lines = nameFile.readlines()
+
+for curLine in lines:                      # 读取行
 
     if not curLine:                         # 若为空行，则直接跳转到下一行
         continue


### PR DESCRIPTION
1. 原本的代码写法有问题，导致txt读取过程中只读取了奇数行的内容，输出文件也只有800余行。修复后可以正常读取所有行，输出文件大约有1700余行。
2. 考虑到源文件可能有部分遗漏未翻或者有各种原因没有翻译的行，添加了几行语句，现在会将遍历每行内容过程中遇到的格式不对的行输出到一个单独txt。PR里也有这个新文件，是运行结果，可以检查一下。